### PR TITLE
Fix float service maturity progress bar labels

### DIFF
--- a/src/components/EntityOpsLevelMaturityProgress.tsx
+++ b/src/components/EntityOpsLevelMaturityProgress.tsx
@@ -68,18 +68,25 @@ export function EntityOpsLevelMaturityProgress({ levels, serviceLevel }: { level
         >
           <div>
             {levelIcon}
-            <span
+            <div
               style={{
-                textAlign: 'center',
-                position: 'absolute',
-                marginTop: '30px',
-                width: '120px',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
+                width: "0px",
+                height: "0px",
+                display: "block",
+                position: "relative",
+                transform: "translate(-60px)"
               }}
             >
-              {level.name}
-            </span>
+              <div style={{
+                width: "120px",
+                textAlign: "center",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap"
+              }}>
+                {level.name}
+              </div>
+            </div>
           </div>
         </Tooltip>
         {last ? null : progressComponent}
@@ -96,6 +103,8 @@ export function EntityOpsLevelMaturityProgress({ levels, serviceLevel }: { level
           justifyContent: 'space-between',
           width: '100%',
           minHeight: '90px',
+          paddingLeft: '25px',
+          paddingRight: '25px'
         }}
       >
         {levelComponents}


### PR DESCRIPTION
https://gitlab.com/jklabsinc/opslevel-bs/-/issues/2

The labels were floating out of the containing info card when the screen height was reduced and vertical scrolling happened on the service maturity page. This PR fixed that.