### PR TITLE
Update version for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-opslevel-maturity",
-  "version": "0.4.7",
+  "version": "1.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
https://docs.npmjs.com/about-semantic-versioning

Setting version of both the backend and the frontend plugin to v1.0.0.

For the backend one, I created a tagged release on GitHub as well, I think for this repo I'm lacking the permissions. Could you do that @sergio-opslevel ?