### PR TITLE
show scorecards in category breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
   * Adds storybook
+  * Adds support for Scorecards
 
 ## [1.1.2] - 2023-10-24
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -92,9 +92,11 @@ export class OpsLevelGraphqlAPI implements OpsLevelApi {
     return this.client.request(query, { alias: serviceAlias }, { "GraphQL-Visibility": "internal" });
   }
 
-  getServicesReport() {
+  getServicesReport(includeScorecards: boolean) {
     const query = gql`
-      query servicesReport {
+      query servicesReport(
+        $includeScorecards: Boolean
+      ) {
         account {
           rubric {
             levels {
@@ -119,7 +121,7 @@ export class OpsLevelGraphqlAPI implements OpsLevelApi {
               }
               serviceCount
             }
-            categoryLevelCounts {
+            categoryLevelCounts(includeScorecards: $includeScorecards) {
               category {
                 name
               }
@@ -134,7 +136,7 @@ export class OpsLevelGraphqlAPI implements OpsLevelApi {
       }    
     `;
 
-    return this.client.request(query, { }, { "GraphQL-Visibility": "internal" });
+    return this.client.request(query, { includeScorecards }, { "GraphQL-Visibility": "internal" });
   }
 
   exportEntity(entity: Entity) {

--- a/src/components/OverallMaturity.tsx
+++ b/src/components/OverallMaturity.tsx
@@ -25,7 +25,7 @@ export const OverallMaturity = () => {
   const opslevelApi = useApi(opslevelApiRef);
   const opslevelPluginApi = useApi(opslevelPluginApiRef);
   const [fetchState, doFetch] = useAsyncFn(async () => {
-    const result = await opslevelApi.getServicesReport();
+    const result = await opslevelApi.getServicesReport(true);
 
     if (result) {
       setData(result);

--- a/src/types/OpsLevelData.ts
+++ b/src/types/OpsLevelData.ts
@@ -81,7 +81,7 @@ export type OpsLevelApi = {
   url: string;
   getServiceMaturityByAlias: (serviceAlias: string) => Promise<any>;
   exportEntity: (entity: Entity) => Promise<any>;
-  getServicesReport: () => Promise<any>;
+  getServicesReport: (includeScorecards: boolean) => Promise<any>;
 }
 
 export type AutoSyncConfiguration = {


### PR DESCRIPTION
## What changes did you make?

- Exposes scorecards that affect service maturity to the Category Breakdown chart

## Is there a ticket that you are fixing?

[*Please link it here if so*](https://gitlab.com/jklabsinc/opslevel-bs/-/issues/13)

## Changelog

- [ ] I have updated the changelog or given a reason why this does not need an entry in this section.

## Screenshots

<img width="1332" alt="Screenshot 2023-10-27 at 10 19 26 AM" src="https://github.com/OpsLevel/backstage-plugin/assets/33187974/c7e25f3b-020b-440e-9783-01e763e0014b">


<details>
<summary>Collapsed Screenshots</summary>
</details
