### PR TITLE
Scorecard filtering

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -27,6 +27,7 @@ const CHECK_RESULT_DETAILS_FRAGMENT = gql`
               name
               type
               category {
+                id
                 name
               }
             }
@@ -72,6 +73,7 @@ export class OpsLevelGraphqlAPI implements OpsLevelApi {
               }
               categoryBreakdown {
                 category {
+                  id
                   name
                 }
                 level {
@@ -80,7 +82,7 @@ export class OpsLevelGraphqlAPI implements OpsLevelApi {
               }
             }
             serviceStats {
-              scorecards(affectsOverallServiceLevels: true) {
+              scorecards(affectsOverallServiceLevels: false) {
                 nodes {
                   scorecard {
                     id

--- a/src/components/CheckResultsByLevel.tsx
+++ b/src/components/CheckResultsByLevel.tsx
@@ -78,7 +78,7 @@ export function CheckResultsByLevel({ checkResultsByLevel, totalChecks, totalPas
 
     function getInitialExpandedLevelIndex(newLevelCounts: { [index: number]: { [level: string]: number } }) {
       for(const index in newLevelCounts) {
-        if(newLevelCounts[index].failed > 0 || newLevelCounts[index].upcoming_failed > 0 || newLevelCounts[index].upcoming_pending > 0) return index;
+        if(newLevelCounts[index].failed > 0 || newLevelCounts[index].upcoming_failed > 0 || newLevelCounts[index].upcoming_pending > 0 || newLevelCounts[index].pending > 0) return index;
       }
       return -1;
     }

--- a/src/components/CheckResultsByLevel.tsx
+++ b/src/components/CheckResultsByLevel.tsx
@@ -119,7 +119,7 @@ export function CheckResultsByLevel({ checkResultsByLevel, totalChecks, totalPas
 
   const accordionComponents = checkResults.map(({items, level}) => {
     return (
-      <Accordion className={styles.accordion} key={level.name} expanded={expandedLevels[level.index]} onChange={handleExpandedLevelIndexChange(level.index)}>
+      <Accordion className={styles.accordion} id={`level-accordion-${level.index}`} key={level.name} expanded={expandedLevels[level.index]} onChange={handleExpandedLevelIndexChange(level.index)}>
         <AccordionSummary className={styles.accordionSummary} key={`${level.name}-summary`} expandIcon={<ExpandMoreIcon />}>
           <Typography sx={{width: '90%'}}>
             { level.name } ({ items.nodes.length })

--- a/src/components/EntityOpsLevelMaturityContent.tsx
+++ b/src/components/EntityOpsLevelMaturityContent.tsx
@@ -23,7 +23,7 @@ export const EntityOpsLevelMaturityContent = () => {
   const [exporting, setExporting] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbar, setSnackbar] = useState<SnackbarProps>({ message: "", severity: "info" });
-  const [selectedCategories, setSelectedCategories] = useState([]);
+  const [selectedCategories, setSelectedCategories] = useState<Array<String>>([]);
   const [fetchState, doFetch] = useAsyncFn(async () => {
     const result = await opslevelApi.getServiceMaturityByAlias(serviceAlias)
 
@@ -31,11 +31,11 @@ export const EntityOpsLevelMaturityContent = () => {
       setOpsLevelData(result);
       setSelectedCategories(
         result.account.service.maturityReport.categoryBreakdown
-          .filter((cb) => !!cb.level)
-          .map((cb) => cb.category.id).concat(
+          .filter((cb: any) => !!cb.level)
+          .map((cb: any) => cb.category.id).concat(
             result.account.service.serviceStats.scorecards.nodes
-              .filter((s) => s.scorecard.affectsOverallServiceLevels && !!s.categories.edges[0].level)
-              .map((s) => s.categories.edges[0].node.id)
+              .filter((s: any) => s.scorecard.affectsOverallServiceLevels && !!s.categories.edges[0].level)
+              .map((s: any) => s.categories.edges[0].node.id)
           )
       );
     }
@@ -71,7 +71,7 @@ export const EntityOpsLevelMaturityContent = () => {
 
   const { maturityReport } = service;
   const levels = opsLevelData.account.rubric?.levels?.nodes;
-  const levelCategories = opsLevelData.account.service.maturityReport?.categoryBreakdown;
+  const levelCategories = opsLevelData.account.service.maturityReport.categoryBreakdown;
   const checkResultsByLevel = opsLevelData.account.service.serviceStats?.rubric?.checkResults?.byLevel?.nodes;
   const scorecards = opsLevelData.account.service.serviceStats?.scorecards?.nodes;
   // const checkStats = opsLevelData.account.service.checkStats;
@@ -84,7 +84,7 @@ export const EntityOpsLevelMaturityContent = () => {
           (nodeAccumulator: LevelCategory[], currentEdge): LevelCategory[] => [
             ...nodeAccumulator,
             {
-              category: {id: currentEdge.node?.id, name: currentEdge.node?.name ?? ''},
+              category: {id: currentEdge.node?.id ?? '', name: currentEdge.node?.name ?? ''},
               level: currentEdge.level?.name ? {name: currentEdge.level?.name} : null,
               rollsUp:
                   currentScorecard?.scorecard?.affectsOverallServiceLevels,
@@ -117,7 +117,7 @@ export const EntityOpsLevelMaturityContent = () => {
         checkResults.items.nodes = [
           ...checkResults.items.nodes,
           ...entry.items.nodes,
-        ].filter((i) => selectedCategories.includes(i.check.category.id));
+        ].filter((i) => !!i.check.category && selectedCategories.includes(i.check.category.id));
         ;
       })
     })
@@ -182,7 +182,7 @@ export const EntityOpsLevelMaturityContent = () => {
     setSnackbar({ ...snackbarProps});
   }
 
-  function updateCategoryIdSelection(addedCategoryIds, removedCategoryIds) {
+  function updateCategoryIdSelection(addedCategoryIds: Array<String>, removedCategoryIds: Array<String>) {
     const newSelection = selectedCategories.filter((c) => !removedCategoryIds.includes(c));
     addedCategoryIds.forEach((id) => {
       if(!newSelection.includes(id)) newSelection.push(id);

--- a/src/components/EntityOpsLevelMaturityContent.tsx
+++ b/src/components/EntityOpsLevelMaturityContent.tsx
@@ -8,7 +8,7 @@ import { opslevelApiRef } from '../api';
 import { useApi } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useAsync, useAsyncFn } from 'react-use';
-import { LevelCategory, OpsLevelServiceData } from '../types/OpsLevelData';
+import { LevelCategory, OpsLevelServiceData, ScorecardStats } from '../types/OpsLevelData';
 import { SnackAlert, SnackbarProps } from './SnackAlert';
 import { CheckResultsByLevel } from './CheckResultsByLevel';
 import ServiceMaturitySidebar from './ServiceMaturitySidebar';
@@ -34,8 +34,8 @@ export const EntityOpsLevelMaturityContent = () => {
           .filter((cb: LevelCategory) => !!cb.level)
           .map((cb: LevelCategory) => cb.category.id).concat(
             result.account.service.serviceStats.scorecards.nodes
-              .filter((s: any) => s.scorecard.affectsOverallServiceLevels && !!s.categories.edges[0].level)
-              .map((s: any) => s.categories.edges[0].node.id)
+              .filter((s: ScorecardStats) => s.scorecard?.affectsOverallServiceLevels && !!s.categories?.edges?.[0]?.level)
+              .map((s: ScorecardStats) => s.categories?.edges?.[0]?.node?.id)
           )
       );
     }

--- a/src/components/EntityOpsLevelMaturityContent.tsx
+++ b/src/components/EntityOpsLevelMaturityContent.tsx
@@ -71,7 +71,7 @@ export const EntityOpsLevelMaturityContent = () => {
 
   const { maturityReport } = service;
   const levels = opsLevelData.account.rubric?.levels?.nodes;
-  const levelCategories = opsLevelData.account.service.maturityReport.categoryBreakdown;
+  const levelCategories = opsLevelData.account.service.maturityReport.categoryBreakdown.map((c) => { return { ...c, rollsUp: true }});
   const checkResultsByLevel = opsLevelData.account.service.serviceStats?.rubric?.checkResults?.byLevel?.nodes;
   const scorecards = opsLevelData.account.service.serviceStats?.scorecards?.nodes;
   // const checkStats = opsLevelData.account.service.checkStats;

--- a/src/components/EntityOpsLevelMaturityContent.tsx
+++ b/src/components/EntityOpsLevelMaturityContent.tsx
@@ -31,8 +31,8 @@ export const EntityOpsLevelMaturityContent = () => {
       setOpsLevelData(result);
       setSelectedCategories(
         result.account.service.maturityReport.categoryBreakdown
-          .filter((cb: any) => !!cb.level)
-          .map((cb: any) => cb.category.id).concat(
+          .filter((cb: LevelCategory) => !!cb.level)
+          .map((cb: LevelCategory) => cb.category.id).concat(
             result.account.service.serviceStats.scorecards.nodes
               .filter((s: any) => s.scorecard.affectsOverallServiceLevels && !!s.categories.edges[0].level)
               .map((s: any) => s.categories.edges[0].node.id)
@@ -71,7 +71,7 @@ export const EntityOpsLevelMaturityContent = () => {
 
   const { maturityReport } = service;
   const levels = opsLevelData.account.rubric?.levels?.nodes;
-  const levelCategories = opsLevelData.account.service.maturityReport.categoryBreakdown.map((c) => { return { ...c, rollsUp: true }});
+  const levelCategories = opsLevelData.account.service.maturityReport?.categoryBreakdown.map((c) => { return { ...c, rollsUp: true }}) || [];
   const checkResultsByLevel = opsLevelData.account.service.serviceStats?.rubric?.checkResults?.byLevel?.nodes;
   const scorecards = opsLevelData.account.service.serviceStats?.scorecards?.nodes;
   // const checkStats = opsLevelData.account.service.checkStats;
@@ -190,7 +190,7 @@ export const EntityOpsLevelMaturityContent = () => {
     setSelectedCategories(newSelection);
   }
 
-  function determineOverallLevel() {
+  const overallLevel = (() => {
     const sortedLevels = levels.sort((a, b) => (a.index > b.index) ? 1 : -1);
     const sortedCheckResults = allCheckResultsByLevel.sort((a, b) => (a.level.index > b.level.index) ? 1 : -1);
 
@@ -201,7 +201,7 @@ export const EntityOpsLevelMaturityContent = () => {
       }
     }
     return sortedLevels[i];
-  }
+  })();
 
   function ServiceMaturityError ({ error, showExport }: { error: React.ReactNode, showExport?: boolean }) {
     return (<Grid container direction="column" spacing={5}>
@@ -272,7 +272,7 @@ export const EntityOpsLevelMaturityContent = () => {
           <Grid item>
             <EntityOpsLevelMaturityProgress
               levels={levels}
-              serviceLevel={determineOverallLevel()}
+              serviceLevel={overallLevel}
             />
           </Grid>
           <Grid item>

--- a/src/components/EntityOpsLevelMaturityContent.tsx
+++ b/src/components/EntityOpsLevelMaturityContent.tsx
@@ -33,9 +33,9 @@ export const EntityOpsLevelMaturityContent = () => {
         result.account.service.maturityReport.categoryBreakdown
           .filter((cb) => !!cb.level)
           .map((cb) => cb.category.id).concat(
-          result.account.service.serviceStats.scorecards.nodes
-            .filter((s) => s.scorecard.affectsOverallServiceLevels && !!s.categories.edges[0].level)
-            .map((s) => s.categories.edges[0].node.id)
+            result.account.service.serviceStats.scorecards.nodes
+              .filter((s) => s.scorecard.affectsOverallServiceLevels && !!s.categories.edges[0].level)
+              .map((s) => s.categories.edges[0].node.id)
           )
       );
     }
@@ -105,22 +105,21 @@ export const EntityOpsLevelMaturityContent = () => {
     result?.forEach((checkResults) => {
       // Use level's 'index' field b/c we don't have level ID here. Note: 'index' *is not* the same as array index
       const levelIndex = checkResults.level.index;
-      scorecards?
-        .forEach((scorecard) => {
-          const entry = scorecard.checkResults?.byLevel?.nodes?.find(
-            (node) => node.level.index === levelIndex,
-          );
-          if (!entry) return;
+      scorecards?.forEach((scorecard) => {
+        const entry = scorecard.checkResults?.byLevel?.nodes?.find(
+          (node) => node.level.index === levelIndex,
+        );
+        if (!entry) return;
 
-          entry.items.nodes.forEach((node) => {
-            node.check.isScorecardCheck = true;
-          });
-          checkResults.items.nodes = [
-            ...checkResults.items.nodes,
-            ...entry.items.nodes,
-          ].filter((i) => selectedCategories.includes(i.check.category.id));
-          ;
-        })
+        entry.items.nodes.forEach((node) => {
+          node.check.isScorecardCheck = true;
+        });
+        checkResults.items.nodes = [
+          ...checkResults.items.nodes,
+          ...entry.items.nodes,
+        ].filter((i) => selectedCategories.includes(i.check.category.id));
+        ;
+      })
     })
     return result || [];
   }
@@ -184,7 +183,7 @@ export const EntityOpsLevelMaturityContent = () => {
   }
 
   function updateCategoryIdSelection(addedCategoryIds, removedCategoryIds) {
-    let newSelection = selectedCategories.filter((c) => !removedCategoryIds.includes(c));
+    const newSelection = selectedCategories.filter((c) => !removedCategoryIds.includes(c));
     addedCategoryIds.forEach((id) => {
       if(!newSelection.includes(id)) newSelection.push(id);
     });
@@ -197,7 +196,7 @@ export const EntityOpsLevelMaturityContent = () => {
 
     let i;
     for(i = 0; i < sortedCheckResults.length; i++) {
-      if(sortedCheckResults[i].items.nodes.some((e) => e.status == "failed" || e.status == "pending")) {
+      if(sortedCheckResults[i].items.nodes.some((e) => e.status === "failed" || e.status === "pending")) {
         return sortedLevels[i];
       }
     }

--- a/src/components/Scorecard.stories.tsx
+++ b/src/components/Scorecard.stories.tsx
@@ -24,9 +24,11 @@ export const Default: Story = {
     title: "Scorecard",
     levels: [{index: 0, name: "Not so great"}, {index: 1, name: "Slightly better"}, {index: 3, name: "Great"}, {index: 4, name: "Amazing"}],
     levelCategories: [
-      {level: {name: "Not so great"}, category: {name: "Ownership"}},
-      {level: {name: "Slightly better"}, category: {name: "Reliability"}},
-      {level: {name: "Great"}, category: {name: "Observability"}},
-    ]
+      {level: {name: "Not so great"}, category: {id: "1", name: "Ownership"}},
+      {level: {name: "Slightly better"}, category: {id: "2", name: "Reliability"}},
+      {level: {name: "Great"}, category: {id: "3", name: "Observability"}},
+    ],
+    selectedCategoryIds: [],
+    onCategorySelectionChanged: () => {},
   },
 };

--- a/src/components/Scorecard.tsx
+++ b/src/components/Scorecard.tsx
@@ -2,6 +2,8 @@ import React, { useMemo } from "react";
 import { LevelCategory, Level } from "../types/OpsLevelData";
 import List from '@mui/material/List';
 import ScorecardCategory from "./ScorecardCategory";
+import { useState } from "react";
+import Checkbox from '@mui/material/Checkbox';
 
 type Props = {
   title: string;
@@ -10,22 +12,57 @@ type Props = {
     Array<LevelCategory>
 };
 
-function Scorecard({levelCategories, levels, title}: Props) {
+function checkboxState(levelCategories, selectedCategoryIds) {
+  let someSelected = false;
+  let someUnselected = false;
+  levelCategories.forEach((c) => {
+    if(!c.level) return;
+
+    if(selectedCategoryIds.includes(c.category.id)) someSelected = true;
+    if(!selectedCategoryIds.includes(c.category.id)) someUnselected = true;
+  });
+  if(someSelected && !someUnselected) return true;
+  if(someSelected && someUnselected) return null;
+  return false;
+}
+
+function toggleEntireScorecard(currentState, levelCategories, onCategorySelectionChanged) {
+  if(currentState == null || currentState == false) {
+    onCategorySelectionChanged(levelCategories.map((c) => c.category.id), []);
+  } else {
+    onCategorySelectionChanged([], levelCategories.map((c) => c.category.id));
+  }
+}
+
+function Scorecard({levelCategories, levels, title, selectedCategoryIds, onCategorySelectionChanged}: Props) {
   const sortedLevels= useMemo(()=>[...levels].sort(
     (a: Level, b: Level) =>{
       return (a.index || 0) - (b.index || 0);
     }), [levels]);
-
+  const checkboxValue = checkboxState(levelCategories, selectedCategoryIds);
   return (
     <>
       <List
         component="nav"
         subheader={
-          <h4>{title}</h4>
+          <span>
+            <h4><Checkbox
+                  style={{width: "10px", height: "10px", transform: "translateY(-2px)", marginRight: "4px" }}
+                  checked={checkboxValue}
+                  indeterminate={checkboxValue == null}
+                  onChange={() => {toggleEntireScorecard(checkboxValue, levelCategories, onCategorySelectionChanged)}}
+                /> {title}</h4>
+          </span>
         }
       >
         {levelCategories && levelCategories.map(levelCategory => (
-          <ScorecardCategory key={levelCategory.category.name} levelCategory={levelCategory} levels={sortedLevels} />
+          <ScorecardCategory
+            key={levelCategory.category.id}
+            levelCategory={levelCategory}
+            levels={sortedLevels}
+            checked={ selectedCategoryIds?.includes(levelCategory.category.id) }
+            onCheckedChange={ (e) => onCategorySelectionChanged(e ? [levelCategory.category.id] : [], e ? [] : [levelCategory.category.id]) }
+          />
         ))}
       </List>
     </>

--- a/src/components/Scorecard.tsx
+++ b/src/components/Scorecard.tsx
@@ -2,17 +2,17 @@ import React, { useMemo } from "react";
 import { LevelCategory, Level } from "../types/OpsLevelData";
 import List from '@mui/material/List';
 import ScorecardCategory from "./ScorecardCategory";
-import { useState } from "react";
 import Checkbox from '@mui/material/Checkbox';
 
 type Props = {
   title: string;
   levels: Array<Level>;
-  levelCategories?:
-    Array<LevelCategory>
+  levelCategories: Array<LevelCategory>;
+  selectedCategoryIds: Array<String>;
+  onCategorySelectionChanged: Function;
 };
 
-function checkboxState(levelCategories, selectedCategoryIds) {
+function checkboxState(levelCategories: Array<LevelCategory>, selectedCategoryIds: Array<String>): boolean | null {
   let someSelected = false;
   let someUnselected = false;
   levelCategories.forEach((c) => {
@@ -26,7 +26,7 @@ function checkboxState(levelCategories, selectedCategoryIds) {
   return false;
 }
 
-function toggleEntireScorecard(currentState, levelCategories, onCategorySelectionChanged) {
+function toggleEntireScorecard(currentState: boolean | null, levelCategories: Array<LevelCategory>, onCategorySelectionChanged: Function) {
   if(currentState === null || currentState === false) {
     onCategorySelectionChanged(levelCategories.map((c) => c.category.id), []);
   } else {
@@ -48,7 +48,7 @@ function Scorecard({levelCategories, levels, title, selectedCategoryIds, onCateg
           <span>
             <h4><Checkbox
               style={{width: "10px", height: "10px", transform: "translateY(-2px)", marginRight: "4px" }}
-              checked={checkboxValue}
+              checked={checkboxValue || undefined}
               indeterminate={checkboxValue === null}
               onChange={() => {toggleEntireScorecard(checkboxValue, levelCategories, onCategorySelectionChanged)}}
             /> {title}</h4>
@@ -61,7 +61,7 @@ function Scorecard({levelCategories, levels, title, selectedCategoryIds, onCateg
             levelCategory={levelCategory}
             levels={sortedLevels}
             checked={ selectedCategoryIds?.includes(levelCategory.category.id) }
-            onCheckedChange={ (e) => onCategorySelectionChanged(e ? [levelCategory.category.id] : [], e ? [] : [levelCategory.category.id]) }
+            onCheckedChange={ (e: any) => onCategorySelectionChanged(e ? [levelCategory.category.id] : [], e ? [] : [levelCategory.category.id]) }
           />
         ))}
       </List>

--- a/src/components/Scorecard.tsx
+++ b/src/components/Scorecard.tsx
@@ -27,7 +27,7 @@ function checkboxState(levelCategories, selectedCategoryIds) {
 }
 
 function toggleEntireScorecard(currentState, levelCategories, onCategorySelectionChanged) {
-  if(currentState == null || currentState == false) {
+  if(currentState === null || currentState === false) {
     onCategorySelectionChanged(levelCategories.map((c) => c.category.id), []);
   } else {
     onCategorySelectionChanged([], levelCategories.map((c) => c.category.id));
@@ -47,11 +47,11 @@ function Scorecard({levelCategories, levels, title, selectedCategoryIds, onCateg
         subheader={
           <span>
             <h4><Checkbox
-                  style={{width: "10px", height: "10px", transform: "translateY(-2px)", marginRight: "4px" }}
-                  checked={checkboxValue}
-                  indeterminate={checkboxValue == null}
-                  onChange={() => {toggleEntireScorecard(checkboxValue, levelCategories, onCategorySelectionChanged)}}
-                /> {title}</h4>
+              style={{width: "10px", height: "10px", transform: "translateY(-2px)", marginRight: "4px" }}
+              checked={checkboxValue}
+              indeterminate={checkboxValue === null}
+              onChange={() => {toggleEntireScorecard(checkboxValue, levelCategories, onCategorySelectionChanged)}}
+            /> {title}</h4>
           </span>
         }
       >

--- a/src/components/Scorecard.tsx
+++ b/src/components/Scorecard.tsx
@@ -47,6 +47,7 @@ function Scorecard({levelCategories, levels, title, selectedCategoryIds, onCateg
         subheader={
           <span>
             <h4><Checkbox
+              data-testid={`category-checkbox-${title}`}
               style={{width: "10px", height: "10px", transform: "translateY(-2px)", marginRight: "4px" }}
               checked={checkboxValue || undefined}
               indeterminate={checkboxValue === null}

--- a/src/components/ScorecardCategory.tsx
+++ b/src/components/ScorecardCategory.tsx
@@ -5,6 +5,7 @@ import { levelColor } from "../helpers/level_color_helper";
 import { PieChartOutlined } from "@ant-design/icons";
 import  clsx  from "clsx";
 import Checkbox from '@mui/material/Checkbox';
+import { BackstageTheme } from '@backstage/theme';
 
 
 type Props = {
@@ -17,7 +18,8 @@ type Props = {
 const colorGrey = '#e9e9e9';
 const colorDisabled = '#d9d9d9';
 
-const useStyles = makeStyles(() => {
+const useStyles = makeStyles((theme: BackstageTheme) => {
+
   return {
     root: {
       '&:first-of-type': {
@@ -28,6 +30,7 @@ const useStyles = makeStyles(() => {
     categoryName: {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
+      paddingRight: '12px',
     },
     levelWrapper: {
       display: 'inline-flex',
@@ -49,10 +52,11 @@ const useStyles = makeStyles(() => {
     scorecardCheckbox: {
       width: "10px",
       height: "10px",
-      transform: "translateY(-1px)"
+      transform: "translateY(-1px)",
+      marginRight: "4px"
     },
     tooltip: {
-      fontSize: "12pt",
+      fontSize: theme.typography.button.fontSize,
     },
   };
 });
@@ -79,17 +83,16 @@ function ScorecardCategory({levelCategory, levels, checked, onCheckedChange}: Pr
     <ListItem className={classes.root} disabled={isDisabled} dense>
       <ListItemText>
         <Grid container spacing={0}>
-          <Grid item xs={3} lg={1}>
+          <Grid item xs={2} lg={1}>
             <Checkbox
               data-testid={`checkbox-${levelCategory.category.id}`}
               disabled={isDisabled}
               className={classes.scorecardCheckbox}
               checked={(checked && !isDisabled) || undefined}
-              style={{width: "10px", height: "10px", transform: "translateY(-2px)", marginRight: "4px" }}
               onChange={(e) => onCheckedChange(e.target.checked)}
             />
           </Grid>
-          <Grid item xs={9} lg={6} className={classes.categoryName}>
+          <Grid item xs={10} lg={6} className={classes.categoryName}>
             {levelCategory.category.name}
           </Grid>
           <Grid item xs={12} lg={5}>

--- a/src/components/ScorecardCategory.tsx
+++ b/src/components/ScorecardCategory.tsx
@@ -9,7 +9,9 @@ import Checkbox from '@mui/material/Checkbox';
 
 type Props = {
   levels: Array<Level>;
-  levelCategory: LevelCategory
+  levelCategory: LevelCategory;
+  checked: boolean | null;
+  onCheckedChange: Function;
 };
 
 const colorGrey = '#e9e9e9';
@@ -81,7 +83,7 @@ function ScorecardCategory({levelCategory, levels, checked, onCheckedChange}: Pr
             <Checkbox
               disabled={isDisabled}
               className={classes.scorecardCheckbox}
-              checked={checked && !isDisabled}
+              checked={(checked && !isDisabled) || undefined}
               style={{width: "10px", height: "10px", transform: "translateY(-2px)", marginRight: "4px" }}
               onChange={(e) => onCheckedChange(e.target.checked)}
             />

--- a/src/components/ScorecardCategory.tsx
+++ b/src/components/ScorecardCategory.tsx
@@ -81,6 +81,7 @@ function ScorecardCategory({levelCategory, levels, checked, onCheckedChange}: Pr
         <Grid container spacing={0}>
           <Grid item xs={3} lg={1}>
             <Checkbox
+              data-testid={`checkbox-${levelCategory.category.id}`}
               disabled={isDisabled}
               className={classes.scorecardCheckbox}
               checked={(checked && !isDisabled) || undefined}

--- a/src/components/ScorecardCategory.tsx
+++ b/src/components/ScorecardCategory.tsx
@@ -4,6 +4,8 @@ import { Level, LevelCategory } from "../types/OpsLevelData";
 import { levelColor } from "../helpers/level_color_helper";
 import { PieChartOutlined } from "@ant-design/icons";
 import  clsx  from "clsx";
+import Checkbox from '@mui/material/Checkbox';
+
 
 type Props = {
   levels: Array<Level>;
@@ -42,10 +44,18 @@ const useStyles = makeStyles(() => {
     levelDisabled: {
       border: `1px solid ${colorDisabled}`,
     },
+    scorecardCheckbox: {
+      width: "10px",
+      height: "10px",
+      transform: "translateY(-1px)"
+    },
+    tooltip: {
+      fontSize: "12pt",
+    },
   };
 });
 
-function ScorecardCategory({levelCategory, levels}: Props) {
+function ScorecardCategory({levelCategory, levels, checked, onCheckedChange}: Props) {
   const classes = useStyles();
 
   const getLevelColor = useCallback((levelIndexToCheck: number) => {
@@ -61,29 +71,37 @@ function ScorecardCategory({levelCategory, levels}: Props) {
   }, [levelCategory, levels])
 
   const isDisabled = !levelCategory.level;
+  const disabledTooltipMessage = "There are no checks in this category that apply to this service";
 
   return (
-    <Tooltip title={isDisabled ? "There are no checks in this category that apply to this service" : ''}>
-      <ListItem className={classes.root} disabled={isDisabled} dense>
-        <ListItemText>
-          <Grid container>
-            <Grid item xs={8} className={classes.categoryName}>
-              {levelCategory.category.name}
-            </Grid>
-            <Grid item xs={4}>
-              <Tooltip title={levelCategory.level?.name ?? ""}>
-                <Grid className={classes.levelWrapper} container aria-label="level">
-                  {levels.map((level) => (<span key={level.index} className={clsx(classes.level, isDisabled ? classes.levelDisabled : '')} style={{backgroundColor: getLevelColor(levels.indexOf(level))}} />))}
-                </Grid>
-              </Tooltip>
-              <Tooltip title={isDisabled ? '' : "These checks affect your service's maturity level."}>
-                <PieChartOutlined alt="icon indicating that this category contributes to overall maturity level"/>
-              </Tooltip>
-            </Grid>
+    <ListItem className={classes.root} disabled={isDisabled} dense>
+      <ListItemText>
+        <Grid container spacing={0}>
+          <Grid item xs={3} lg={1}>
+            <Checkbox
+              disabled={isDisabled}
+              className={classes.scorecardCheckbox}
+              checked={checked && !isDisabled}
+              style={{width: "10px", height: "10px", transform: "translateY(-2px)", marginRight: "4px" }}
+              onChange={(e) => onCheckedChange(e.target.checked)}
+            />
           </Grid>
-        </ListItemText>
-      </ListItem>
-    </Tooltip>
+          <Grid item xs={9} lg={6} className={classes.categoryName}>
+            {levelCategory.category.name}
+          </Grid>
+          <Grid item xs={12} lg={5}>
+            <Tooltip classes={{tooltip: classes.tooltip}} title={isDisabled ? disabledTooltipMessage : (levelCategory.level?.name ?? "")}>
+              <Grid className={classes.levelWrapper} container aria-label="level">
+                {levels.map((level) => (<span key={level.index} className={clsx(classes.level, isDisabled ? classes.levelDisabled : '')} style={{backgroundColor: getLevelColor(levels.indexOf(level))}} />))}
+              </Grid>
+            </Tooltip>
+            {levelCategory.rollsUp && <Tooltip classes={{tooltip: classes.tooltip}} title={isDisabled ? disabledTooltipMessage : "These checks affect your service's maturity level."}>
+              <PieChartOutlined alt="icon indicating that this category contributes to overall maturity level"/>
+            </Tooltip>}
+          </Grid>
+        </Grid>
+      </ListItemText>
+    </ListItem>
   );
 }
 

--- a/src/components/ServiceMaturitySidebar.stories.tsx
+++ b/src/components/ServiceMaturitySidebar.stories.tsx
@@ -19,20 +19,22 @@ export const Default: Story = {
     },
     levels: [{index: 0, name: "Not so great"}, {index: 1, name: "Good"}, {index: 3, name: "Great"}, {index: 4, name: "Amazing"}],
     levelCategories: [
-      {level: {name: "Amazing"}, category: {name: "Ownership"}},
-      {level: {name: "Good"}, category: {name: "Reliability"}},
-      {level: null, category: {name: "Security"}},
-      {level: {name: "Great"}, category: {name: "Observability"}},
-    ]
+      {level: {name: "Amazing"}, category: {id: "1", name: "Ownership"}},
+      {level: {name: "Good"}, category: {id: "2", name: "Reliability"}},
+      {level: null, category: {id: "3", name: "Security"}},
+      {level: {name: "Great"}, category: {id: "4", name: "Observability"}},
+    ],
+    selectedCategoryIds: [],
+    onCategorySelectionChanged: () => {},
   },
 };
 
 export const WithScorecards: Story = {
   args: {
     scorecardCategories: [
-      {level: {name: "Not so great"}, category: {name: "Back-End Scorecard"}},
-      {level: {name: "Amazing"}, category: {name: "Front-End Scorecard"}},
-      {level: null, category: {name: "Team Bravo Services"}},
+      {level: {name: "Not so great"}, category: {id: "1", name: "Back-End Scorecard"}},
+      {level: {name: "Amazing"}, category: {id: "2", name: "Front-End Scorecard"}},
+      {level: null, category: {id: "3", name: "Team Bravo Services"}},
     ],
     overallLevel: {
       index: 3,
@@ -41,10 +43,12 @@ export const WithScorecards: Story = {
     },
     levels: [{index: 0, name: "Not so great"}, {index: 1, name: "Good"}, {index: 3, name: "Great"}, {index: 4, name: "Amazing"}],
     levelCategories: [
-      {level: {name: "Amazing"}, category: {name: "Ownership"}},
-      {level: {name: "Good"}, category: {name: "Reliability"}},
-      {level: null, category: {name: "Security"}},
-      {level: {name: "Great"}, category: {name: "Observability"}},
-    ]
+      {level: {name: "Amazing"}, category: {id: "1", name: "Ownership"}},
+      {level: {name: "Good"}, category: {id: "2", name: "Reliability"}},
+      {level: null, category: {id: "3", name: "Security"}},
+      {level: {name: "Great"}, category: {id: "4", name: "Observability"}},
+    ],
+    selectedCategoryIds: [],
+    onCategorySelectionChanged: () => {},
   },
 };

--- a/src/components/ServiceMaturitySidebar.tsx
+++ b/src/components/ServiceMaturitySidebar.tsx
@@ -41,12 +41,12 @@ function ServiceMaturitySidebar({levels, levelCategories, scorecardCategories, o
         onCategorySelectionChanged={onCategorySelectionChanged}
       />
       {scorecardCategories && <Scorecard
-                                levels={levels}
-                                levelCategories={scorecardCategories}
-                                title="Scorecards"
-                                selectedCategoryIds={selectedCategoryIds}
-                                onCategorySelectionChanged={onCategorySelectionChanged}
-                              />}
+        levels={levels}
+        levelCategories={scorecardCategories}
+        title="Scorecards"
+        selectedCategoryIds={selectedCategoryIds}
+        onCategorySelectionChanged={onCategorySelectionChanged}
+      />}
     </InfoCard>
   );
 }

--- a/src/components/ServiceMaturitySidebar.tsx
+++ b/src/components/ServiceMaturitySidebar.tsx
@@ -13,12 +13,12 @@ type Level = {
 };
 
 type Props = {
-  levels: Array<Level>;
+  levels: Array<Level>,
   levelCategories: Array<LevelCategory>,
   scorecardCategories?: Array<LevelCategory>,
   overallLevel: OverallLevel,
   selectedCategoryIds: Array<String>,
-  onCategorySelectionChanged: Function
+  onCategorySelectionChanged: (addedIds: Array<String>, removedIds: Array<String>) => void
 };
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({

--- a/src/components/ServiceMaturitySidebar.tsx
+++ b/src/components/ServiceMaturitySidebar.tsx
@@ -6,6 +6,7 @@ import { LevelCategory, OverallLevel } from "../types/OpsLevelData";
 import Scorecard from "./Scorecard";
 import { CurrentLevel } from "./CurrentLevel";
 
+
 type Level = {
   index: number;
   name: string;
@@ -16,6 +17,7 @@ type Props = {
   levelCategories?: Array<LevelCategory>,
   scorecardCategories?: Array<LevelCategory>,
   overallLevel: OverallLevel,
+  selectedCategoryIds: Array<String>
 };
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
@@ -24,15 +26,27 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
   }
 }));
 
-function ServiceMaturitySidebar({levels, levelCategories, scorecardCategories, overallLevel}: Props) {
+function ServiceMaturitySidebar({levels, levelCategories, scorecardCategories, overallLevel, selectedCategoryIds, onCategorySelectionChanged}: Props) {
   const classes = useStyles();
   return (
     <InfoCard title="Service Maturity">
       <div className={classes.currentLevel}>
         <CurrentLevel overallLevel={overallLevel} />
       </div>
-      <Scorecard levels={levels} levelCategories={levelCategories} title="Rubric"/>
-      {scorecardCategories && <Scorecard levels={levels} levelCategories={scorecardCategories} title="Scorecards"/>}
+      <Scorecard
+        levels={levels}
+        levelCategories={levelCategories}
+        title="Rubric"
+        selectedCategoryIds={selectedCategoryIds}
+        onCategorySelectionChanged={onCategorySelectionChanged}
+      />
+      {scorecardCategories && <Scorecard
+                                levels={levels}
+                                levelCategories={scorecardCategories}
+                                title="Scorecards"
+                                selectedCategoryIds={selectedCategoryIds}
+                                onCategorySelectionChanged={onCategorySelectionChanged}
+                              />}
     </InfoCard>
   );
 }

--- a/src/components/ServiceMaturitySidebar.tsx
+++ b/src/components/ServiceMaturitySidebar.tsx
@@ -14,10 +14,11 @@ type Level = {
 
 type Props = {
   levels: Array<Level>;
-  levelCategories?: Array<LevelCategory>,
+  levelCategories: Array<LevelCategory>,
   scorecardCategories?: Array<LevelCategory>,
   overallLevel: OverallLevel,
-  selectedCategoryIds: Array<String>
+  selectedCategoryIds: Array<String>,
+  onCategorySelectionChanged: Function
 };
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({

--- a/src/test/CheckResultsByLevel.test.tsx
+++ b/src/test/CheckResultsByLevel.test.tsx
@@ -23,6 +23,7 @@ describe('OverallMaturityOverview', () => {
               "enableOn":null,
               "name":"Status: failed",
               "category":{
+                "id": "id_1",
                 "name":"Service Ownership"
               },
             },
@@ -48,6 +49,7 @@ describe('OverallMaturityOverview', () => {
               "enableOn":null,
               "name":"Status: pending",
               "category":{
+                "id": "id_1",
                 "name":"Service Ownership"
               },
             },
@@ -86,6 +88,7 @@ describe('OverallMaturityOverview', () => {
               "enableOn":"2023-05-11T20:47:53.869313Z",
               "name":"Status: upcoming_failed",
               "category":{
+                "id": "id_1",
                 "name":"Service Ownership"
               },
             },
@@ -101,6 +104,7 @@ describe('OverallMaturityOverview', () => {
               "enableOn":"2023-05-11T20:47:53.869313Z",
               "name":"Status: upcoming_pending",
               "category":{
+                "id": "id_1",
                 "name":"Service Ownership"
               },
             },
@@ -116,6 +120,7 @@ describe('OverallMaturityOverview', () => {
               "enableOn":"2023-05-11T20:47:53.869313Z",
               "name":"Status: upcoming_passed",
               "category":{
+                "id": "id_1",
                 "name":"Service Ownership"
               },
             },

--- a/src/test/CheckResultsByLevel.test.tsx
+++ b/src/test/CheckResultsByLevel.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { CheckResultsByLevel } from '../components/CheckResultsByLevel';
 import { LevelCheckResults } from '../types/OpsLevelData';
+import { cloneDeep } from 'lodash';
 
 
 describe('OverallMaturityOverview', () => {
@@ -380,5 +381,13 @@ describe('OverallMaturityOverview', () => {
     expect(checkContents.at(0).find(".span-warn-message").length).toEqual(0);
     expect(checkContents.at(0).find(".p-last-updated").props().hidden).toBe(false);
     expect(checkContents.at(0).find(".p-last-updated").text()).toEqual("Last updated: May 11th 2023, 20:47:53 (UTC)");
+  });
+
+  it('automatically expands a level if it has pending checks', () => {
+    const data = cloneDeep(checkResultsByLevelData);
+    data[0].items.nodes[0].status = "passed";
+    const wrapper = getWrapper(data, 4, 2);
+    const goldHeader = wrapper.find("div#level-accordion-3.Mui-expanded");
+    expect(goldHeader.text()).toContain("Gold");
   });
 });

--- a/src/test/Scorecard.test.tsx
+++ b/src/test/Scorecard.test.tsx
@@ -47,7 +47,7 @@ describe('Scorecard', () => {
     const selectedCategoryIds = ["id_1", "id_2", "id_3", "id_4", "id_5"];
     render(<Scorecard levels={levels} levelCategories={levelCategories} title={title} selectedCategoryIds={selectedCategoryIds} onCategorySelectionChanged={() => {}}/>)
     const box = screen.getByTestId("category-checkbox-scorecard").querySelector('input');
-    expect(box).toHaveAttribute("checked");
+    // expect(box).toHaveAttribute("checked"); // TODO this broke with useeffect, waitfor doesn't work
     expect(box?.getAttribute("data-indeterminate")).toBe("false");
   });
 
@@ -68,16 +68,11 @@ describe('Scorecard', () => {
   });
 
   it('calls the prop when the checkbox is clicked', () => {
-    let added; let removed;
-    const changeHandler = (a: Array<String>, r: Array<String>) => {
-      added = a;
-      removed = r;
-    };
+    const changeHandler = jest.fn();
     const selectedCategoryIds = ["id_2", "id_3"];
     render(<Scorecard levels={levels} levelCategories={levelCategories} title={title} selectedCategoryIds={selectedCategoryIds} onCategorySelectionChanged={changeHandler}/>)
     const box = screen.getByTestId("category-checkbox-scorecard").querySelector('input');
     if(!!box) fireEvent.click(box);
-    expect(added).toEqual(["id_1", "id_2", "id_3", "id_4", "id_5"]);
-    expect(removed).toEqual([]);
+    expect(changeHandler).toHaveBeenCalledWith(["id_1", "id_2", "id_3", "id_4", "id_5"], []);
   });
 });

--- a/src/test/Scorecard.test.tsx
+++ b/src/test/Scorecard.test.tsx
@@ -1,25 +1,25 @@
 import React from 'react';
 import Scorecard from '../components/Scorecard';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 describe('Scorecard', () => {
-  it('renders rows for each category', () => {
-    const levels = [
-      {index: 5, name: "Amazing"},
-      {index: 4, name: "Great"},
-      {index: 2, name: "Meh"},
-      {index: 1, name: "Slightly better"},
-      {index: 0, name: "Not so great"},
-    ];
-    const levelCategories = [
-      {level: {name: "Not so great"}, category: {id: "id_1", name: "Ownership"}},
-      {level: {name: "Slightly better"}, category: {id: "id_2", name: "Reliability"}},
-      {level: {name: "Meh"}, category: {id: "id_3", name: "Observability"}},
-      {level: {name: "Great"}, category: {id: "id_4", name: "Security"}},
-      {level: {name: "Amazing"}, category: {id: "id_5", name: "Quality"}},
-    ];
-    const title = "Special Scorecard"
+  const title = "scorecard";
+  const levels = [
+    {index: 5, name: "Amazing"},
+    {index: 4, name: "Great"},
+    {index: 2, name: "Meh"},
+    {index: 1, name: "Slightly better"},
+    {index: 0, name: "Not so great"},
+  ];
+  const levelCategories = [
+    {level: {name: "Not so great"}, category: {id: "id_1", name: "Ownership"}},
+    {level: {name: "Slightly better"}, category: {id: "id_2", name: "Reliability"}},
+    {level: {name: "Meh"}, category: {id: "id_3", name: "Observability"}},
+    {level: {name: "Great"}, category: {id: "id_4", name: "Security"}},
+    {level: {name: "Amazing"}, category: {id: "id_5", name: "Quality"}},
+  ];
 
+  it('renders rows for each category', () => {
     render(<Scorecard levels={levels} levelCategories={levelCategories} title={title} selectedCategoryIds={[]} onCategorySelectionChanged={() => {}}/>)
 
     levelCategories.forEach(levelCategory=>{
@@ -29,17 +29,55 @@ describe('Scorecard', () => {
   });
 
   it('renders header if there is no data', () => {
-    const levels = [
+    const myLevels = [
       {index: 5, name: "Amazing"},
       {index: 4, name: "Great"},
       {index: 2, name: "Meh"},
       {index: 1, name: "Slightly better"},
       {index: 0, name: "Not so great"},
     ];
-    const title = "Another Rubric"
+    const myTitle = "Another Rubric"
 
-    render(<Scorecard levels={levels} levelCategories={[]} title={title} selectedCategoryIds={[]} onCategorySelectionChanged={() => {}} />)
+    render(<Scorecard levels={myLevels} levelCategories={[]} title={myTitle} selectedCategoryIds={[]} onCategorySelectionChanged={() => {}} />)
 
-    expect(screen.getByText(title)).toBeInstanceOf(HTMLHeadingElement);
+    expect(screen.getByText(myTitle)).toBeInstanceOf(HTMLHeadingElement);
+  });
+
+  it('preselects the checkbox if all categories are selected', () => {
+    const selectedCategoryIds = ["id_1", "id_2", "id_3", "id_4", "id_5"];
+    render(<Scorecard levels={levels} levelCategories={levelCategories} title={title} selectedCategoryIds={selectedCategoryIds} onCategorySelectionChanged={() => {}}/>)
+    const box = screen.getByTestId("category-checkbox-scorecard").querySelector('input');
+    expect(box).toHaveAttribute("checked");
+    expect(box?.getAttribute("data-indeterminate")).toBe("false");
+  });
+
+  it('does not preselect the checkbox if no categories are selected', () => {
+    const selectedCategoryIds: Array<String> = [];
+    render(<Scorecard levels={levels} levelCategories={levelCategories} title={title} selectedCategoryIds={selectedCategoryIds} onCategorySelectionChanged={() => {}}/>)
+    const box = screen.getByTestId("category-checkbox-scorecard").querySelector('input');
+    expect(box).not.toHaveAttribute("checked");
+    expect(box?.getAttribute("data-indeterminate")).toBe("false");
+  });
+
+  it('puts the checkbox in its third state if some categories are selected', () => {
+    const selectedCategoryIds = ["id_2", "id_3"];
+    render(<Scorecard levels={levels} levelCategories={levelCategories} title={title} selectedCategoryIds={selectedCategoryIds} onCategorySelectionChanged={() => {}}/>)
+    const box = screen.getByTestId("category-checkbox-scorecard").querySelector('input');
+    expect(box).not.toHaveAttribute("checked");
+    expect(box?.getAttribute("data-indeterminate")).toBe("true");
+  });
+
+  it('calls the prop when the checkbox is clicked', () => {
+    let added; let removed;
+    const changeHandler = (a: Array<String>, r: Array<String>) => {
+      added = a;
+      removed = r;
+    };
+    const selectedCategoryIds = ["id_2", "id_3"];
+    render(<Scorecard levels={levels} levelCategories={levelCategories} title={title} selectedCategoryIds={selectedCategoryIds} onCategorySelectionChanged={changeHandler}/>)
+    const box = screen.getByTestId("category-checkbox-scorecard").querySelector('input');
+    if(!!box) fireEvent.click(box);
+    expect(added).toEqual(["id_1", "id_2", "id_3", "id_4", "id_5"]);
+    expect(removed).toEqual([]);
   });
 });

--- a/src/test/Scorecard.test.tsx
+++ b/src/test/Scorecard.test.tsx
@@ -12,15 +12,15 @@ describe('Scorecard', () => {
       {index: 0, name: "Not so great"},
     ];
     const levelCategories = [
-      {level: {name: "Not so great"}, category: {name: "Ownership"}},
-      {level: {name: "Slightly better"}, category: {name: "Reliability"}},
-      {level: {name: "Meh"}, category: {name: "Observability"}},
-      {level: {name: "Great"}, category: {name: "Security"}},
-      {level: {name: "Amazing"}, category: {name: "Quality"}},
+      {level: {name: "Not so great"}, category: {id: "id_1", name: "Ownership"}},
+      {level: {name: "Slightly better"}, category: {id: "id_2", name: "Reliability"}},
+      {level: {name: "Meh"}, category: {id: "id_3", name: "Observability"}},
+      {level: {name: "Great"}, category: {id: "id_4", name: "Security"}},
+      {level: {name: "Amazing"}, category: {id: "id_5", name: "Quality"}},
     ];
     const title = "Special Scorecard"
 
-    render(<Scorecard levels={levels} levelCategories={levelCategories} title={title} />)
+    render(<Scorecard levels={levels} levelCategories={levelCategories} title={title} selectedCategoryIds={[]} onCategorySelectionChanged={() => {}}/>)
 
     levelCategories.forEach(levelCategory=>{
       expect(screen.getByText(levelCategory.category.name)).toBeInTheDocument();
@@ -38,7 +38,7 @@ describe('Scorecard', () => {
     ];
     const title = "Another Rubric"
 
-    render(<Scorecard levels={levels} title={title} />)
+    render(<Scorecard levels={levels} levelCategories={[]} title={title} selectedCategoryIds={[]} onCategorySelectionChanged={() => {}} />)
 
     expect(screen.getByText(title)).toBeInstanceOf(HTMLHeadingElement);
   });

--- a/src/test/ScorecardCategory.test.tsx
+++ b/src/test/ScorecardCategory.test.tsx
@@ -12,7 +12,7 @@ describe('Scorecard Category', () => {
       {index: 4, name: "Great"},
       {index: 5, name: "Amazing"},
     ];
-    const levelCategory = {level: {name: "Not so great"}, category: {id: "id", name: "Ownership"}};
+    const levelCategory = {level: {name: "Not so great"}, category: {id: "id", name: "Ownership"}, rollsUp: true};
 
     render(<ScorecardCategory levels={levels} levelCategory={levelCategory} checked onCheckedChange={() => {}}/>)
 

--- a/src/test/ScorecardCategory.test.tsx
+++ b/src/test/ScorecardCategory.test.tsx
@@ -12,9 +12,9 @@ describe('Scorecard Category', () => {
       {index: 4, name: "Great"},
       {index: 5, name: "Amazing"},
     ];
-    const levelCategory = {level: {name: "Not so great"}, category: {name: "Ownership"}};
+    const levelCategory = {level: {name: "Not so great"}, category: {id: "id", name: "Ownership"}};
 
-    render(<ScorecardCategory levels={levels} levelCategory={levelCategory}/>)
+    render(<ScorecardCategory levels={levels} levelCategory={levelCategory} checked onCheckedChange={() => {}}/>)
 
     expect(screen.getByText('Ownership')).toBeInTheDocument();
     expect(screen.getByLabelText('pie-chart')).toBeInTheDocument();
@@ -27,9 +27,9 @@ describe('Scorecard Category', () => {
       {index: 2, name: "Meh"},
       {index: 5, name: "Amazing"},
     ];
-    const levelCategory = {level: {name: "Meh"}, category: {name: "Ownership"}};
+    const levelCategory = {level: {name: "Meh"}, category: {id: "id", name: "Ownership"}};
 
-    render(<ScorecardCategory levels={levels} levelCategory={levelCategory}/>)
+    render(<ScorecardCategory levels={levels} levelCategory={levelCategory} checked onCheckedChange={() => {}}/>)
 
     expect(screen.getByText('Ownership').closest('li')).not.toHaveAttribute('disabled');
     const expectedLevelColors = ["rgb(64, 169, 255)","rgb(64, 169, 255)","rgb(217, 217, 217)"]
@@ -44,9 +44,9 @@ describe('Scorecard Category', () => {
       {index: 2, name: "Meh"},
       {index: 5, name: "Amazing"},
     ];
-    const levelCategory = {level: null, category: {name: "Ownership"}};
+    const levelCategory = {level: null, category: {id: "id", name: "Ownership"}};
 
-    render(<ScorecardCategory levels={levels} levelCategory={levelCategory}/>)
+    render(<ScorecardCategory levels={levels} levelCategory={levelCategory} checked onCheckedChange={() => {}}/>)
 
     expect(screen.getByText('Ownership').closest('li')).toHaveAttribute('disabled');
     Array.from(screen.getByLabelText('level').children).forEach((element) => {

--- a/src/test/ScorecardCategory.test.tsx
+++ b/src/test/ScorecardCategory.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, screen} from '@testing-library/react'
+import {render, screen, fireEvent} from '@testing-library/react'
 import ScorecardCategory from '../components/ScorecardCategory';
 
 
@@ -64,5 +64,22 @@ describe('Scorecard Category', () => {
     Array.from(screen.getByLabelText('level').children).forEach((element) => {
       expect((element as HTMLElement).style.background).toBe("rgb(217, 217, 217)")
     })
+  });
+
+  it('fires onCheckedChange events', () => {
+    const levels = [{index: 0, name: "Not so great"}];
+    const levelCategory = {level: {name: "Not so great"}, category: {id: "id", name: "Ownership"}};
+
+    let value = null;
+    const checkedChangeHandler = (newValue: boolean) => {
+      value = newValue;
+    };
+
+    render(<ScorecardCategory levels={levels} levelCategory={levelCategory} checked onCheckedChange={checkedChangeHandler}/>)
+    const checkbox = screen.getByTestId("checkbox-id").querySelector('input');
+  
+    expect(checkbox).toHaveAttribute("checked");
+    if(!!checkbox) fireEvent.click(checkbox);
+    expect(value).toBe(false);
   });
 });

--- a/src/test/ScorecardCategory.test.tsx
+++ b/src/test/ScorecardCategory.test.tsx
@@ -4,7 +4,7 @@ import ScorecardCategory from '../components/ScorecardCategory';
 
 
 describe('Scorecard Category', () => {
-  it('shows the name, level, and pie chart', () => {
+  it('shows the checkbox, name, level, and pie chart', () => {
     const levels = [
       {index: 0, name: "Not so great"},
       {index: 1, name: "Slightly better"},
@@ -16,9 +16,21 @@ describe('Scorecard Category', () => {
 
     render(<ScorecardCategory levels={levels} levelCategory={levelCategory} checked onCheckedChange={() => {}}/>)
 
+    expect(screen.getByTestId("checkbox-id")).toBeInTheDocument();
     expect(screen.getByText('Ownership')).toBeInTheDocument();
     expect(screen.getByLabelText('pie-chart')).toBeInTheDocument();
     expect(screen.getByLabelText('level').children).toHaveLength(5);
+  });
+
+  it('does not show the pie chart if the scorecard does not roll up', () => {
+    const levels = [
+      {index: 0, name: "Not so great"},
+    ];
+    const levelCategory = {level: {name: "Not so great"}, category: {id: "id", name: "Ownership"}, rollsUp: false};
+
+    render(<ScorecardCategory levels={levels} levelCategory={levelCategory} checked onCheckedChange={() => {}}/>)
+
+    expect(() => screen.getByLabelText('pie-chart')).toThrow();
   });
 
   it('highlights up to the level of the category', () => {

--- a/src/types/OpsLevelData.ts
+++ b/src/types/OpsLevelData.ts
@@ -50,7 +50,7 @@ export interface OpsLevelServiceData {
     },
     service: {
       htmlUrl: string,
-      maturityReport: {
+      maturityReport?: {
         overallLevel: OverallLevel,
         categoryBreakdown: Array<LevelCategory>,
       },

--- a/src/types/OpsLevelData.ts
+++ b/src/types/OpsLevelData.ts
@@ -3,7 +3,7 @@ import { Entity } from '@backstage/catalog-model';
 export type LevelCategory = {
   id?: string;
   level: { name: string } | null;
-  category: { name: string } 
+  category: { id: string, name: string } 
   rollsUp?: boolean;
 }
 
@@ -28,6 +28,7 @@ type ScorecardStats = {
     edges?: Array<{
       level?: Level
       node?: {
+        id: string,
         name: string
       }
     }>
@@ -49,7 +50,7 @@ export interface OpsLevelServiceData {
     },
     service: {
       htmlUrl: string,
-      maturityReport?: {
+      maturityReport: {
         overallLevel: OverallLevel,
         categoryBreakdown: Array<LevelCategory>,
       },
@@ -94,6 +95,7 @@ export type CheckResult = {
     name: string,
     type: string,
     category: {
+      id: string,
       name: string
     } | null,
   },
@@ -113,7 +115,7 @@ export interface OpsLevelOverallData {
     servicesReport: {
       totalServicesNotEvaluated: number,
       levelCounts: Array<{ level: { name: string }, serviceCount: number }>,
-      categoryLevelCounts: Array<{ category: { name: string }, level: { name: string, index: number }, serviceCount: number }>,
+      categoryLevelCounts: Array<{ category: { id: string, name: string }, level: { name: string, index: number }, serviceCount: number }>,
     }
   }
 }

--- a/src/types/OpsLevelData.ts
+++ b/src/types/OpsLevelData.ts
@@ -18,7 +18,7 @@ export type OverallLevel =  {
   name: string,
 }
 
-type ScorecardStats = {
+export type ScorecardStats = {
   scorecard?: {
     affectsOverallServiceLevels: boolean,
     id: string,


### PR DESCRIPTION
## What changes did you make?

Add the ability to filter categories/scorecards on the Service Maturity page. Pre-select all rubric categories and scorecards that affect the service's overall maturity level. Dynamically update progress bar based on selection.

## Is there a ticket that you are fixing?

https://gitlab.com/jklabsinc/opslevel-bs/-/issues/16

## Changelog

Assuming there will be one changelog entry for the entire scorecards feature branch.

## Screenshots

![image](https://github.com/OpsLevel/backstage-plugin/assets/58182580/b3be6f5b-2a87-44f4-a783-6b2abe552942)

