### PR TITLE
Make entire category/scorecard row clickable

### DIFF
--- a/src/components/ScorecardCategory.tsx
+++ b/src/components/ScorecardCategory.tsx
@@ -19,6 +19,7 @@ const colorGrey = '#e9e9e9';
 const colorDisabled = '#d9d9d9';
 
 const useStyles = makeStyles((theme: BackstageTheme) => {
+  console.log(theme);
   return {
     root: {
       '&:first-of-type': {
@@ -27,7 +28,7 @@ const useStyles = makeStyles((theme: BackstageTheme) => {
       borderBottom: `1px solid ${colorGrey}`,
       cursor: "pointer",
       '&:hover': {
-        backgroundColor: theme.palette.infoBackground
+        backgroundColor: "#0000FF11"
       },
       "&.Mui-disabled": {
         cursor: "not-allowed"

--- a/src/components/ScorecardCategory.tsx
+++ b/src/components/ScorecardCategory.tsx
@@ -19,7 +19,6 @@ const colorGrey = '#e9e9e9';
 const colorDisabled = '#d9d9d9';
 
 const useStyles = makeStyles((theme: BackstageTheme) => {
-  console.log(theme);
   return {
     root: {
       '&:first-of-type': {
@@ -28,7 +27,7 @@ const useStyles = makeStyles((theme: BackstageTheme) => {
       borderBottom: `1px solid ${colorGrey}`,
       cursor: "pointer",
       '&:hover': {
-        backgroundColor: "#0000FF11"
+        backgroundColor: theme.palette.background.default
       },
       "&.Mui-disabled": {
         cursor: "not-allowed"

--- a/src/components/ScorecardCategory.tsx
+++ b/src/components/ScorecardCategory.tsx
@@ -19,13 +19,19 @@ const colorGrey = '#e9e9e9';
 const colorDisabled = '#d9d9d9';
 
 const useStyles = makeStyles((theme: BackstageTheme) => {
-
   return {
     root: {
       '&:first-of-type': {
         borderTop: `1px solid ${colorGrey}`,
       },
       borderBottom: `1px solid ${colorGrey}`,
+      cursor: "pointer",
+      '&:hover': {
+        backgroundColor: theme.palette.infoBackground
+      },
+      "&.Mui-disabled": {
+        cursor: "not-allowed"
+      }
     },
     categoryName: {
       overflow: 'hidden',
@@ -78,9 +84,14 @@ function ScorecardCategory({levelCategory, levels, checked, onCheckedChange}: Pr
 
   const isDisabled = !levelCategory.level;
   const disabledTooltipMessage = "There are no checks in this category that apply to this service";
+  const isChecked = (checked && !isDisabled) || undefined;
+
+  const toggleChecked = () => {
+    onCheckedChange(!isChecked);
+  }
 
   return (
-    <ListItem className={classes.root} disabled={isDisabled} dense>
+    <ListItem className={classes.root} disabled={isDisabled} dense onClick={toggleChecked}>
       <ListItemText>
         <Grid container spacing={0}>
           <Grid item xs={2} lg={1}>
@@ -88,8 +99,7 @@ function ScorecardCategory({levelCategory, levels, checked, onCheckedChange}: Pr
               data-testid={`checkbox-${levelCategory.category.id}`}
               disabled={isDisabled}
               className={classes.scorecardCheckbox}
-              checked={(checked && !isDisabled) || undefined}
-              onChange={(e) => onCheckedChange(e.target.checked)}
+              checked={isChecked}
             />
           </Grid>
           <Grid item xs={10} lg={6} className={classes.categoryName}>


### PR DESCRIPTION
## What changes did you make?

- Make entire category/scorecard row clickable instead of just the checkbox on the service maturity page

## Is there a ticket that you are fixing?

No

## Changelog

Don't think this warrants one either

## Screenshots

![image](https://github.com/OpsLevel/backstage-plugin/assets/58182580/96ddb18d-c738-4f91-acb3-28fc6919e4fd)
