### PR TITLE
Shows correct icon and tooltip for scorecardsg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+  * Shows different icon for category and scorecard in check result
+
 ## [1.2.0] - 2023-11-03
 
 ### Added

--- a/src/components/CheckResultDetails.stories.tsx
+++ b/src/components/CheckResultDetails.stories.tsx
@@ -131,3 +131,30 @@ export const Payload: Story = {
     }
   },
 };
+
+export const Scorecard: Story = {
+  args: {
+    combinedStatus: "failed",
+    checkResult: {
+      message: "Ticket number 34 has caused the reduction from 76% to 72%.",
+      warnMessage: "Health has dipped to 72%. The limit is 74%.",
+      createdAt: `${new Date()}`,
+      check: {
+        id: '1',
+        enableOn: null,
+        isScorecardCheck: true,
+        name: 'Scorecard check',
+        type: 'payload',
+        category: {
+          id: '1989',
+          name: 'First scorecard',
+          container: {
+            href: '/categories/quality',
+          },
+        },
+        owner: null,
+      },
+      status: 'failed',
+    }
+  },
+};

--- a/src/components/CheckResultDetails.tsx
+++ b/src/components/CheckResultDetails.tsx
@@ -1,11 +1,11 @@
-import { Link, Typography, Box } from '@material-ui/core';
+import { Link, Typography, Box, Tooltip } from '@material-ui/core';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import CancelIcon from '@material-ui/icons/Cancel';
 import WatchLaterIcon from '@material-ui/icons/WatchLater';
 import ErrorIcon from '@material-ui/icons/Error';
 import { Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
 import moment from 'moment';
-import { TableOutlined, TeamOutlined } from '@ant-design/icons';
+import { FileDoneOutlined, TableOutlined, TeamOutlined } from '@ant-design/icons';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import React, { ReactElement, useState } from 'react';
 import { CheckResult, CheckResultStatus } from '../types/OpsLevelData';
@@ -35,6 +35,9 @@ const useStyles = makeStyles((theme: BackstageTheme) => {
       marginRight: theme.spacing(1),
       display: "inline-flex",
     },
+    infoTooltip: {
+      fontSize: theme.typography.button.fontSize,
+    }
   };
 });
 
@@ -115,7 +118,12 @@ export function CheckResultDetails ({ checkResult, combinedStatus, opslevelUrl }
             {checkResult.check.category && <>
               <span className={styles.separator}>&#65372;</span>
               <span className={styles.coloredSubtext}>
-                <TableOutlined className={styles.checkResultIcon} />
+                <Tooltip className={styles.infoTooltip} title={`This check belongs to ${checkResult.check.isScorecardCheck ? "a scorecard." : "the main rubric"}.`}>
+                  <span>
+                    {checkResult.check.isScorecardCheck && <FileDoneOutlined className={styles.checkResultIcon} />}
+                    {!checkResult.check.isScorecardCheck && <TableOutlined className={styles.checkResultIcon} />}
+                  </span>
+                </Tooltip>
                 {opslevelUrl && <Link href={`${opslevelUrl}${checkResult.check.category.container.href}`}>{ checkResult.check.category.name }</Link>}
                 {!opslevelUrl && <>{checkResult.check.category.name}</>}
               </span>

--- a/src/test/CheckResultDetails.test.tsx
+++ b/src/test/CheckResultDetails.test.tsx
@@ -18,8 +18,6 @@ const getCheckResult = (status: CheckResultStatus):CheckResult => ({
   status
 })
 
-    
-
 describe('CheckResultDetails', () => {
   it('renders a check with baseline information', () => {  
     const checkResult = getCheckResult('failed');
@@ -275,4 +273,43 @@ describe('CheckResultDetails', () => {
       expanded: false,
     })).not.toHaveClass('Mui-expanded')
   });
+
+  it('shows a table icon for categories', () => {
+    const checkResult = getCheckResult('failed');
+    checkResult.check.category = {
+      id: '1989',
+      name: 'Tigers',
+      container: {
+        href: '/services/cats',
+      }
+    }
+
+    render(<CheckResultDetails
+      checkResult={checkResult}
+      combinedStatus="passed"
+    />);
+
+    expect(screen.getByLabelText("table")).toBeInTheDocument()
+    expect(screen.queryByLabelText("file-done")).not.toBeInTheDocument()
+  })
+
+  it('shows a file-done icon for scorecards', () => {
+    const checkResult = getCheckResult('failed');
+    checkResult.check.isScorecardCheck = true;
+    checkResult.check.category = {
+      id: '1989',
+      name: 'Tigers',
+      container: {
+        href: '/services/cats',
+      }
+    }
+
+    render(<CheckResultDetails
+      checkResult={checkResult}
+      combinedStatus="passed"
+    />);
+
+    expect(screen.queryByLabelText("table")).not.toBeInTheDocument()
+    expect(screen.getByLabelText("file-done")).toBeInTheDocument()
+  })
 });


### PR DESCRIPTION
## What changes did you make?

- Shows scorecard icon and tooltip for check results that are from scorecards

## Is there a ticket that you are fixing?

N/A, follow on from earlier.

## Changelog

- [x] I have updated the changelog or given a reason why this does not need an entry in this section.

## Screenshots

![Screenshot 2023-11-03 at 5 14 12 PM](https://github.com/OpsLevel/backstage-plugin/assets/479643/c335e762-e08f-4f4f-90c8-5c84f18f6aa7)
![Screenshot 2023-11-03 at 5 14 17 PM](https://github.com/OpsLevel/backstage-plugin/assets/479643/5f89f5fc-a9bd-4aff-8637-0b04b54c7c91)
