### PR TITLE
Prevents scorecard section from showing up when it returns an empty array

### DIFF
--- a/src/components/ServiceMaturitySidebar.stories.tsx
+++ b/src/components/ServiceMaturitySidebar.stories.tsx
@@ -18,6 +18,7 @@ export const Default: Story = {
       description: 'Your services are on their way but still can be better. Primarily, you should be focused on styling and maintainability now that security concerns are out of the way.'
     },
     levels: [{index: 0, name: "Not so great"}, {index: 1, name: "Good"}, {index: 3, name: "Great"}, {index: 4, name: "Amazing"}],
+    scorecardCategories: [],
     levelCategories: [
       {level: {name: "Amazing"}, category: {id: "1", name: "Ownership"}},
       {level: {name: "Good"}, category: {id: "2", name: "Reliability"}},

--- a/src/components/ServiceMaturitySidebar.tsx
+++ b/src/components/ServiceMaturitySidebar.tsx
@@ -41,7 +41,7 @@ function ServiceMaturitySidebar({levels, levelCategories, scorecardCategories, o
         selectedCategoryIds={selectedCategoryIds}
         onCategorySelectionChanged={onCategorySelectionChanged}
       />
-      {scorecardCategories && <Scorecard
+      {scorecardCategories && scorecardCategories.length > 0 && <Scorecard
         levels={levels}
         levelCategories={scorecardCategories}
         title="Scorecards"


### PR DESCRIPTION
## What changes did you make?

- Prevents scorecard section from showing up for empty responses

## Is there a ticket that you are fixing?

[*Please link it here if so*](https://gitlab.com/jklabsinc/opslevel-bs/-/issues/27)

## Changelog

- [x] I have updated the changelog or given a reason why this does not need an entry in this section.

## Screenshots

*Please delete this section if it is not relevant*

Before:

![Screenshot 2023-11-03 at 5 40 48 PM](https://github.com/OpsLevel/backstage-plugin/assets/479643/c6cc9854-1f78-4789-9d19-ba8447a608d0)
