### PR TITLE
Explicit npm registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          registry-url: https://registry.npmjs.org
       - name: Install dependencies
         run: yarn install
       - name: Bump release version

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "registry": "https://registry.npmjs.org"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What changes did you make?

- Explicitly adds npm registry per https://stackoverflow.com/questions/72016612/unable-to-publish-an-npm-package-with-github-actions advice

## Is there a ticket that you are fixing?

[*Please link it here if so*](https://gitlab.com/jklabsinc/opslevel-bs/-/issues/15)

## Changelog

- [x] I have added a Changie entry or given a reason why this does not need an entry in this section.

Not user facing