### PR TITLE
Use baseUrl from config in frontend

### DIFF
--- a/.changes/unreleased/Added-20240124-183811.yaml
+++ b/.changes/unreleased/Added-20240124-183811.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: OpsLevel base url can now be configured for self-hosted instances
+time: 2024-01-24T18:38:11.124042-05:00

--- a/.changes/unreleased/Added-20240125-144745.yaml
+++ b/.changes/unreleased/Added-20240125-144745.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Bumped react-js-cron version to ^5.0.1
+time: 2024-01-25T14:47:45.56626-05:00

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,19 @@
 # Contributing
 
-1. [About this document](#about-this-document)
-2. [Proposing a change](#proposing-a-change)
-3. [Getting the code](#getting-the-code)
-4. [Local development](#local-development)
-5. [Submitting a Pull Request](#submitting-a-pull-request)
-6. [Releasing](#releasing)
+- [Contributing](#contributing)
+  - [About this document](#about-this-document)
+  - [Proposing a change](#proposing-a-change)
+    - [Defining the problem](#defining-the-problem)
+    - [Submitting a change](#submitting-a-change)
+  - [Getting the code](#getting-the-code)
+    - [Installing git](#installing-git)
+    - [External contributors](#external-contributors)
+    - [OpsLevel contributors](#opslevel-contributors)
+  - [Local Development](#local-development)
+    - [Installation](#installation)
+    - [Changie (Change log generation)](#changie-change-log-generation)
+  - [Submitting a Pull Request](#submitting-a-pull-request)
+  - [Releasing](#releasing)
 
 ## About this document
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Setting up this plugin requires the following changes to the `app-config.yaml` f
 
 ### Set Up Proxy Configuration
 
-Add a proxy configuration for OpsLevel. Replace `<your_OpsLevel_API_token>` with a token from https://app.opslevel.com/api_tokens.
+Add a proxy configuration for OpsLevel. Replace `<your_OpsLevel_API_token>` with a token from https://app.opslevel.com/api_tokens (or, if you're running a self-hosted OpsLevel instance, the `/api_tokens` page on your OpsLevel instance).
 
 ```yaml
 proxy:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ With the plugin, you can view maturity progress in context with the rest of your
 yarn add --cwd packages/app @opslevel/backstage-maturity
 ```
 
-Update `app-config.yaml` to add a proxy for OpsLevel. Replace `<your_OpsLevel_API_token>` with a token from https://app.opslevel.com/api_tokens.
+Setting up this plugin requires the following changes to the `app-config.yaml` file:
+
+### Set Up Proxy Configuration
+
+Add a proxy configuration for OpsLevel. Replace `<your_OpsLevel_API_token>` with a token from https://app.opslevel.com/api_tokens.
 
 ```yaml
 proxy:
@@ -47,6 +51,14 @@ proxy:
 
 If you're running Self-Hosted OpsLevel, replace `target` with your URL.
 
+### Set Up the Base OpsLevel URL
+
+```yaml
+opslevel:
+  baseUrl: 'https://app.opslevel.com'
+```
+
+If you're running Self-Hosted OpsLevel, replace `target` with your URL.
 
 ## Add Route & Global nav
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ opslevel:
   baseUrl: 'https://app.opslevel.com'
 ```
 
-If you're running Self-Hosted OpsLevel, replace `target` with your URL.
+If you're running Self-Hosted OpsLevel, replace `baseUrl` with your URL.
 
 ## Add Route & Global nav
 

--- a/config.d.ts
+++ b/config.d.ts
@@ -1,0 +1,9 @@
+export interface Config {
+  opslevel: {
+    /**
+     * OpsLevel instance URL
+     * @visibility frontend
+     */
+    baseUrl: string;
+  };
+}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react": "^17.0.0",
     "react-apexcharts": "^1.4.0",
     "react-dom": "^16.8.0 || ^17.0.0",
-    "react-js-cron": "^3.2.0",
+    "react-js-cron": "^5.0.1",
     "react-router": "6.0.0-beta.0 || ^6.3.0",
     "react-router-dom": "^6.3.0",
     "react-use": "^17.2.4",

--- a/package.json
+++ b/package.json
@@ -112,8 +112,10 @@
     "@types/react-dom": "^17"
   },
   "files": [
-    "dist"
+    "dist",
+    "config.d.ts"
   ],
+  "configSchema": "config.d.ts",
   "keywords": [
     "backstage",
     "service maturity",

--- a/src/components/CheckResultDetails.stories.tsx
+++ b/src/components/CheckResultDetails.stories.tsx
@@ -1,10 +1,29 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import {
+  MockConfigApi,
+  TestApiProvider,
+  wrapInTestApp,
+} from "@backstage/test-utils";
+import { configApiRef } from "@backstage/core-plugin-api";
 
 import CheckResultDetails from "./CheckResultDetails";
+
+const mockConfig = new MockConfigApi({
+  opslevel: { baseUrl: "https://example.com" },
+});
 
 const meta = {
   title: "CheckResultDetails",
   component: CheckResultDetails,
+  decorators: [
+    (Story) => (
+      wrapInTestApp(
+        <TestApiProvider apis={[[configApiRef, mockConfig]]}>
+          <Story />
+        </TestApiProvider>
+      )
+    )
+  ]
 } satisfies Meta<typeof CheckResultDetails>;
 
 export default meta;

--- a/src/components/CheckResultDetails.stories.tsx
+++ b/src/components/CheckResultDetails.stories.tsx
@@ -13,7 +13,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Passing: Story = {
   args: {
-    opslevelUrl: "https://app.opslevel.com",
     combinedStatus: "passed",
     checkResult: {
       message:
@@ -44,7 +43,6 @@ export const Passing: Story = {
 
 export const Pending: Story = {
   args: {
-    opslevelUrl: "https://app.opslevel.com",
     combinedStatus: "pending",
     checkResult: {
       message:

--- a/src/components/CheckResultDetails.stories.tsx
+++ b/src/components/CheckResultDetails.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
 import {
   MockConfigApi,
   TestApiProvider,
@@ -16,14 +17,13 @@ const meta = {
   title: "CheckResultDetails",
   component: CheckResultDetails,
   decorators: [
-    (Story) => (
+    (Story) =>
       wrapInTestApp(
         <TestApiProvider apis={[[configApiRef, mockConfig]]}>
           <Story />
-        </TestApiProvider>
-      )
-    )
-  ]
+        </TestApiProvider>,
+      ),
+  ],
 } satisfies Meta<typeof CheckResultDetails>;
 
 export default meta;

--- a/src/components/CheckResultDetails.tsx
+++ b/src/components/CheckResultDetails.tsx
@@ -15,11 +15,11 @@ import {
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import React, { ReactElement, useState } from "react";
 import { BackstageTheme } from "@backstage/theme";
+import { useApi, configApiRef } from "@backstage/core-plugin-api";
 import { CheckResult, CheckResultStatus } from "../types/OpsLevelData";
 import MarkdownViewer from "./MarkdownViewer";
 
 type Props = {
-  opslevelUrl?: string;
   checkResult: CheckResult;
   combinedStatus: CheckResultStatus;
 };
@@ -71,12 +71,13 @@ const getResultMessage = (checkResult: CheckResult) => {
 export default function CheckResultDetails({
   checkResult,
   combinedStatus,
-  opslevelUrl,
 }: Props) {
   const [expanded, setExpanded] = useState<boolean>(
     combinedStatus.endsWith("failed") || combinedStatus.endsWith("pending"),
   );
   const styles = useStyles();
+  const config = useApi(configApiRef);
+  const opslevelUrl = config.getString("opslevel.baseUrl");
 
   const handleOnExpansionChange = (
     _: React.SyntheticEvent,
@@ -167,14 +168,11 @@ export default function CheckResultDetails({
                       )}
                     </span>
                   </Tooltip>
-                  {opslevelUrl && (
-                    <Link
-                      href={`${opslevelUrl}${checkResult.check.category.container.href}`}
-                    >
-                      {checkResult.check.category.name}
-                    </Link>
-                  )}
-                  {!opslevelUrl && checkResult.check.category.name}
+                  <Link
+                    href={`${opslevelUrl}${checkResult.check.category.container.href}`}
+                  >
+                    {checkResult.check.category.name}
+                  </Link>
                 </span>
               </>
             )}
@@ -184,14 +182,9 @@ export default function CheckResultDetails({
                 <span className={styles.coloredSubtext}>
                   <TeamOutlined className={styles.checkResultIcon} />
                   {}
-                  {opslevelUrl && (
-                    <Link
-                      href={`${opslevelUrl}${checkResult.check.owner.href}`}
-                    >
-                      {checkResult.check.owner.name}
-                    </Link>
-                  )}
-                  {!opslevelUrl && checkResult.check.owner.name}
+                  <Link href={`${opslevelUrl}${checkResult.check.owner.href}`}>
+                    {checkResult.check.owner.name}
+                  </Link>
                 </span>
               </>
             )}

--- a/src/components/CheckResultsByLevel.tsx
+++ b/src/components/CheckResultsByLevel.tsx
@@ -20,7 +20,6 @@ import {
 import CheckResultDetails from "./CheckResultDetails";
 
 type Props = {
-  opslevelUrl?: string;
   checkResultsByLevel: Array<LevelCheckResults>;
   totalChecks: number;
   totalPassingChecks: number;
@@ -74,7 +73,6 @@ function getCombinedStatus(checkResult: CheckResult): CheckResultStatus {
 }
 
 export default function CheckResultsByLevel({
-  opslevelUrl,
   checkResultsByLevel,
   totalChecks,
   totalPassingChecks,
@@ -225,7 +223,6 @@ export default function CheckResultsByLevel({
             return (
               <CheckResultDetails
                 key={`details-${level.name}-${index}`}
-                opslevelUrl={opslevelUrl}
                 checkResult={checkResult}
                 combinedStatus={getCombinedStatus(checkResult)}
               />

--- a/src/components/ExportEntitiesForm.tsx
+++ b/src/components/ExportEntitiesForm.tsx
@@ -35,11 +35,6 @@ function useListAllEntities() {
   };
 }
 
-function useBaseOpsLevelUrl() {
-  const config = useApi(configApiRef);
-  return config.getString("opslevel.baseUrl");
-}
-
 function startExportMessage(entity: Entity) {
   const entityRef = stringifyEntityRef(entity);
   return `Exporting ${entityRef}... `;
@@ -102,7 +97,8 @@ export default function ExportEntityForm() {
   const opslevelApi = useApi(opslevelApiRef);
 
   const entityStates = useListAllEntities();
-  const baseUrl = useBaseOpsLevelUrl();
+  const config = useApi(configApiRef);
+  const baseUrl = config.getString("opslevel.baseUrl");
 
   const error =
     entityStates.components.error ||

--- a/src/components/ExportEntitiesForm.tsx
+++ b/src/components/ExportEntitiesForm.tsx
@@ -10,7 +10,7 @@ import {
 } from "@material-ui/core";
 import { catalogApiRef } from "@backstage/plugin-catalog-react";
 import { Entity, stringifyEntityRef } from "@backstage/catalog-model";
-import { useApi } from "@backstage/core-plugin-api";
+import { useApi, configApiRef } from "@backstage/core-plugin-api";
 import { useAsync } from "react-use";
 import { BackstageTheme } from "@backstage/theme";
 import { OpsLevelApi } from "../types/OpsLevelData";
@@ -33,6 +33,11 @@ function useListAllEntities() {
     users: useListEntities("user"),
     groups: useListEntities("group"),
   };
+}
+
+function useBaseOpsLevelUrl() {
+  const config = useApi(configApiRef);
+  return config.getString("opslevel.baseUrl");
 }
 
 function startExportMessage(entity: Entity) {
@@ -97,6 +102,8 @@ export default function ExportEntityForm() {
   const opslevelApi = useApi(opslevelApiRef);
 
   const entityStates = useListAllEntities();
+  const baseUrl = useBaseOpsLevelUrl();
+
   const error =
     entityStates.components.error ||
     entityStates.users.error ||
@@ -214,7 +221,7 @@ export default function ExportEntityForm() {
           variant="contained"
           color="primary"
           target="_blank"
-          href="https://app.opslevel.com/reports/rubric"
+          href={`${baseUrl}/reports/rubric`}
         >
           View Full Maturity Report in OpsLevel
         </Button>

--- a/src/components/ServiceMaturityReport.tsx
+++ b/src/components/ServiceMaturityReport.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Button, Grid } from "@material-ui/core";
 import { cloneDeep } from "lodash";
-import { useEntity } from "@backstage/plugin-catalog-react";
 import EntityOpsLevelMaturityProgress from "./EntityOpsLevelMaturityProgress";
 import CheckResultsByLevel from "./CheckResultsByLevel";
 import ServiceMaturitySidebar from "./ServiceMaturitySidebar";
@@ -37,15 +36,6 @@ export default function ServiceMaturityReport({
   overallLevel,
   onCategorySelectionChange,
 }: Props) {
-  const { entity } = useEntity();
-  let opslevelUrl = "https://app.opslevel.com";
-  if (service) {
-    const extensionToRemove = `/services/${entity.metadata.name}`;
-    opslevelUrl = service.htmlUrl
-      .split(extensionToRemove)
-      .filter((s) => s)
-      .join(extensionToRemove);
-  }
   const levelCategories =
     service.maturityReport?.categoryBreakdown.map((c) => {
       return { ...c, rollsUp: true };
@@ -225,7 +215,6 @@ export default function ServiceMaturityReport({
           </Grid>
           <Grid item>
             <CheckResultsByLevel
-              opslevelUrl={opslevelUrl}
               checkResultsByLevel={allCheckResultsByLevel}
               totalChecks={totalChecks()}
               totalPassingChecks={totalPassingChecks()}

--- a/src/test/BackendExportEntitiesForm.test.tsx
+++ b/src/test/BackendExportEntitiesForm.test.tsx
@@ -86,7 +86,6 @@ describe("BackendExportEntitiesForm", () => {
   it("displays the execution header as expected if it is the first execution", async () => {
     await renderComponent();
 
-    screen.debug(screen.getByTestId("execution-header"));
     expect(screen.getByTestId("execution-header")).toHaveTextContent(
       "<<< Showing execution 1 of 10 >>>",
     );

--- a/src/test/CheckResultDetails.test.tsx
+++ b/src/test/CheckResultDetails.test.tsx
@@ -28,16 +28,21 @@ const getCheckResult = (status: CheckResultStatus): CheckResult => ({
   status,
 });
 
+const customRender = async (component: React.JSX.Element) => {
+  return renderInTestApp(
+    <TestApiProvider apis={[[configApiRef, mockConfig]]}>
+      {component}
+    </TestApiProvider>,
+  );
+};
+
 describe("CheckResultDetails", () => {
   it("renders a check with baseline information", async () => {
     const checkResult = getCheckResult("failed");
     checkResult.createdAt = "2023-05-11T20:47:53.869313Z";
 
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails checkResult={checkResult} combinedStatus="failed" />
-        ,
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails checkResult={checkResult} combinedStatus="failed" />,
     );
 
     const header = screen.getByRole("button");
@@ -68,11 +73,8 @@ describe("CheckResultDetails", () => {
     const checkResult = getCheckResult("failed");
     checkResult.check.type = "payload";
 
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails checkResult={checkResult} combinedStatus="failed" />
-        ,
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails checkResult={checkResult} combinedStatus="failed" />,
     );
 
     expect(
@@ -102,11 +104,8 @@ describe("CheckResultDetails", () => {
       },
     };
 
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails checkResult={checkResult} combinedStatus="failed" />
-        ,
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails checkResult={checkResult} combinedStatus="failed" />,
     );
 
     const header = screen.getByRole("button");
@@ -127,11 +126,8 @@ describe("CheckResultDetails", () => {
       href: ownerHref,
     };
 
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails checkResult={checkResult} combinedStatus="failed" />
-        ,
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails checkResult={checkResult} combinedStatus="failed" />,
     );
 
     const header = screen.getByRole("button");
@@ -147,11 +143,8 @@ describe("CheckResultDetails", () => {
     const checkResult = getCheckResult("failed");
     checkResult.check.type = "generic";
 
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails checkResult={checkResult} combinedStatus="failed" />
-        ,
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails checkResult={checkResult} combinedStatus="failed" />,
     );
 
     expect(
@@ -170,13 +163,11 @@ describe("CheckResultDetails", () => {
   });
 
   it("renders a failing check in the right color", async () => {
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails
-          checkResult={getCheckResult("failed")}
-          combinedStatus="failed"
-        />
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails
+        checkResult={getCheckResult("failed")}
+        combinedStatus="failed"
+      />,
     );
 
     expect(screen.getByRole("button").parentNode).toHaveStyle({
@@ -185,13 +176,11 @@ describe("CheckResultDetails", () => {
   });
 
   it("renders a pending check in the right color", async () => {
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails
-          checkResult={getCheckResult("pending")}
-          combinedStatus="pending"
-        />
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails
+        checkResult={getCheckResult("pending")}
+        combinedStatus="pending"
+      />,
     );
 
     expect(screen.getByRole("button").parentNode).toHaveStyle({
@@ -200,13 +189,11 @@ describe("CheckResultDetails", () => {
   });
 
   it("renders a passed check in the right color", async () => {
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails
-          checkResult={getCheckResult("passed")}
-          combinedStatus="passed"
-        />
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails
+        checkResult={getCheckResult("passed")}
+        combinedStatus="passed"
+      />,
     );
 
     expect(screen.getByRole("button").parentNode).toHaveStyle({
@@ -215,13 +202,11 @@ describe("CheckResultDetails", () => {
   });
 
   it("renders an upcoming_failed check in the right color with an upcoming message", async () => {
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails
-          checkResult={getCheckResult("upcoming_failed")}
-          combinedStatus="upcoming_failed"
-        />
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails
+        checkResult={getCheckResult("upcoming_failed")}
+        combinedStatus="upcoming_failed"
+      />,
     );
 
     expect(
@@ -236,13 +221,11 @@ describe("CheckResultDetails", () => {
   });
 
   it("renders an upcoming_pending check in the right color with an upcoming message", async () => {
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails
-          checkResult={getCheckResult("upcoming_pending")}
-          combinedStatus="upcoming_pending"
-        />
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails
+        checkResult={getCheckResult("upcoming_pending")}
+        combinedStatus="upcoming_pending"
+      />,
     );
 
     expect(
@@ -257,13 +240,11 @@ describe("CheckResultDetails", () => {
   });
 
   it("renders an upcoming_passed check in the right color with an upcoming message", async () => {
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails
-          checkResult={getCheckResult("upcoming_passed")}
-          combinedStatus="upcoming_passed"
-        />
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails
+        checkResult={getCheckResult("upcoming_passed")}
+        combinedStatus="upcoming_passed"
+      />,
     );
 
     expect(
@@ -278,13 +259,11 @@ describe("CheckResultDetails", () => {
   });
 
   it("expands upcoming failing tests", async () => {
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails
-          checkResult={getCheckResult("upcoming_failed")}
-          combinedStatus="upcoming_failed"
-        />
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails
+        checkResult={getCheckResult("upcoming_failed")}
+        combinedStatus="upcoming_failed"
+      />,
     );
 
     expect(
@@ -296,13 +275,11 @@ describe("CheckResultDetails", () => {
   });
 
   it("expands failing tests", async () => {
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails
-          checkResult={getCheckResult("failed")}
-          combinedStatus="failed"
-        />
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails
+        checkResult={getCheckResult("failed")}
+        combinedStatus="failed"
+      />,
     );
 
     expect(
@@ -314,13 +291,11 @@ describe("CheckResultDetails", () => {
   });
 
   it("does not expand passing tests", async () => {
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails
-          checkResult={getCheckResult("passed")}
-          combinedStatus="passed"
-        />
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails
+        checkResult={getCheckResult("passed")}
+        combinedStatus="passed"
+      />,
     );
 
     expect(
@@ -341,10 +316,8 @@ describe("CheckResultDetails", () => {
       },
     };
 
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails checkResult={checkResult} combinedStatus="passed" />
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails checkResult={checkResult} combinedStatus="passed" />,
     );
 
     expect(screen.getByLabelText("table")).toBeInTheDocument();
@@ -362,10 +335,8 @@ describe("CheckResultDetails", () => {
       },
     };
 
-    await renderInTestApp(
-      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <CheckResultDetails checkResult={checkResult} combinedStatus="passed" />
-      </TestApiProvider>,
+    await customRender(
+      <CheckResultDetails checkResult={checkResult} combinedStatus="passed" />,
     );
 
     expect(screen.queryByLabelText("table")).not.toBeInTheDocument();

--- a/src/test/CheckResultsByLevel.test.tsx
+++ b/src/test/CheckResultsByLevel.test.tsx
@@ -1,8 +1,18 @@
 import React from "react";
 import { mount } from "enzyme";
 import { cloneDeep } from "lodash";
+import {
+  MockConfigApi,
+  wrapInTestApp,
+  TestApiProvider,
+} from "@backstage/test-utils";
+import { configApiRef } from "@backstage/core-plugin-api";
 import CheckResultsByLevel from "../components/CheckResultsByLevel";
 import { LevelCheckResults } from "../types/OpsLevelData";
+
+const mockConfig = new MockConfigApi({
+  opslevel: { baseUrl: "https://example.com" },
+});
 
 describe("CheckResultsByLevel", () => {
   const checkResultsByLevelData: Array<LevelCheckResults> = [
@@ -167,13 +177,17 @@ describe("CheckResultsByLevel", () => {
     passingChecks: number,
   ) =>
     mount(
-      <CheckResultsByLevel
-        checkResultsByLevel={data}
-        totalChecks={totalChecks}
-        totalPassingChecks={passingChecks}
-      />,
+      wrapInTestApp(
+        <TestApiProvider apis={[[configApiRef, mockConfig]]}>
+          <CheckResultsByLevel
+            checkResultsByLevel={data}
+            totalChecks={totalChecks}
+            totalPassingChecks={passingChecks}
+          />
+          ,
+        </TestApiProvider>,
+      ),
     );
-
   it("renders the header check correctly when things make sense", () => {
     const wrapper = getWrapper(checkResultsByLevelData, 4, 2);
 
@@ -201,14 +215,14 @@ describe("CheckResultsByLevel", () => {
   it("renders the appropriate number of accordion elements", () => {
     const wrapper = getWrapper(checkResultsByLevelData, 4, 2);
 
-    const checkSummaries = wrapper.find("div.MuiAccordionSummary-root");
+    const checkSummaries = wrapper.find("div.v5-MuiAccordionSummary-root");
     expect(checkSummaries.length).toEqual(10); // 4 levels + 6 checks
   });
 
   it("renders the right level headers", () => {
     const wrapper = getWrapper(checkResultsByLevelData, 4, 2);
 
-    const checkSummaries = wrapper.find("div.MuiAccordionSummary-root");
+    const checkSummaries = wrapper.find("div.v5-MuiAccordionSummary-root");
 
     const bronzeLevelHeader = checkSummaries.at(0);
     const bronzeLevelHeaderParagraphs = bronzeLevelHeader.find("p");

--- a/yarn.lock
+++ b/yarn.lock
@@ -15270,10 +15270,10 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-js-cron@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-js-cron/-/react-js-cron-3.2.0.tgz#f3f3b0312077fa03594b8c769174478a0b4763e5"
-  integrity sha512-DAluNX6ZpfsSDAIAfJKNyWIckTWTcQ/7IK91J4jaS4o4iihRJo/8gd7kf6ACDTE2RKt0PiSpOf1MBrrSdmdyUQ==
+react-js-cron@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-js-cron/-/react-js-cron-5.0.1.tgz#7228652679c4bf3bb8ecf44c08b7d92f6975741a"
+  integrity sha512-qHUb/qWeMvXklGW6/hLtH9CjboRU7pu2hHxGGErUDTjHDOLn/b6CZHvVsx/e3ak+UObwf4Y0BHSQJzpn1JpvvA==
 
 react-markdown@^8.0.0:
   version "8.0.7"


### PR DESCRIPTION
## What changes did you make?

- added a schema to use `opslevel.baseUrl` in the frontend plugin. This is a required step, otherwise the value is inaccessible to the frontend plugin
- used the baseUrl in the few places we were hard-coding the OpsLevel url - the "View Full Maturity Report in OpsLevel" button on the `ExportEntitiesForm` at `/opslevel-maturity`

## Changelog

- [x] I have added a Changie entry or given a reason why this does not need an entry in this section.

## Screenshots

<img width="641" alt="Screenshot 2024-01-24 at 6 32 21 PM" src="https://github.com/OpsLevel/backstage-plugin/assets/2941718/7dc042b0-7e9d-432a-a7ea-4e36a6e95e14">

