### PR TITLE
Bump react-js-cron to 5.0.1

### DIFF
--- a/.changes/unreleased/Added-20240125-144745.yaml
+++ b/.changes/unreleased/Added-20240125-144745.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Bumped react-js-cron version to ^5.0.1
+time: 2024-01-25T14:47:45.56626-05:00

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react": "^17.0.0",
     "react-apexcharts": "^1.4.0",
     "react-dom": "^16.8.0 || ^17.0.0",
-    "react-js-cron": "^3.2.0",
+    "react-js-cron": "^5.0.1",
     "react-router": "6.0.0-beta.0 || ^6.3.0",
     "react-router-dom": "^6.3.0",
     "react-use": "^17.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15270,10 +15270,10 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-js-cron@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-js-cron/-/react-js-cron-3.2.0.tgz#f3f3b0312077fa03594b8c769174478a0b4763e5"
-  integrity sha512-DAluNX6ZpfsSDAIAfJKNyWIckTWTcQ/7IK91J4jaS4o4iihRJo/8gd7kf6ACDTE2RKt0PiSpOf1MBrrSdmdyUQ==
+react-js-cron@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-js-cron/-/react-js-cron-5.0.1.tgz#7228652679c4bf3bb8ecf44c08b7d92f6975741a"
+  integrity sha512-qHUb/qWeMvXklGW6/hLtH9CjboRU7pu2hHxGGErUDTjHDOLn/b6CZHvVsx/e3ak+UObwf4Y0BHSQJzpn1JpvvA==
 
 react-markdown@^8.0.0:
   version "8.0.7"


### PR DESCRIPTION
## What changes did you make?

Bumped the version of `react-js-cron` to the current latest (5.0.1). I did this to remove some noisy logging about deprecated properties that react-js-cron was using in the underlying `antd` components, and it did fix that, but it leaves us with a different noisy error about a memory leak re: setting state on an unmounted component.

It's not ideal, but it's a single instance of the offending component, in one place in this plugin. This should be good enough until we can find a way (fork? build-in-house? test trickery) to control that behaviour.

## Changelog

- [x] I have added a Changie entry or given a reason why this does not need an entry in this section.

