### PR TITLE
Show nothing if there are not campaigns

### DIFF
--- a/.changes/unreleased/Fixed-20240315-170108.yaml
+++ b/.changes/unreleased/Fixed-20240315-170108.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Campaigns section showed without campaigns and now it does not
+time: 2024-03-15T17:01:08.389314-05:00

--- a/src/components/Campaigns.tsx
+++ b/src/components/Campaigns.tsx
@@ -38,7 +38,7 @@ export default function Campaigns({ serviceId }: Props) {
     };
     fetchCampaigns();
   }, []);
-  if (!campaignsByService) {
+  if (!campaignsByService?.length) {
     return null;
   }
 

--- a/src/test/Campaigns.test.tsx
+++ b/src/test/Campaigns.test.tsx
@@ -103,7 +103,6 @@ describe("Campaigns", () => {
 
   it("shows nothing if there are no campaigns", async () => {
     const serviceId = "123";
-    const checksByCampaign = getChecksByCampaign();
 
     const mockOpsLevelConfig = getMockOpsLevelConfig();
     mockOpsLevelConfig.getCampaigns.mockImplementationOnce(() =>

--- a/src/test/Campaigns.test.tsx
+++ b/src/test/Campaigns.test.tsx
@@ -100,4 +100,39 @@ describe("Campaigns", () => {
       await screen.findByText(checksByCampaign.campaign!.name),
     ).toBeInTheDocument();
   });
+
+  it("shows nothing if there are no campaigns", async () => {
+    const serviceId = "123";
+    const checksByCampaign = getChecksByCampaign();
+
+    const mockOpsLevelConfig = getMockOpsLevelConfig();
+    mockOpsLevelConfig.getCampaigns.mockImplementationOnce(() =>
+      Promise.resolve({
+        account: {
+          service: {
+            campaignReport: {
+              checkResultsByCampaign: { nodes: [] },
+            },
+          },
+        },
+      }),
+    );
+
+    render(
+      wrapInTestApp(
+        <TestApiProvider
+          apis={[
+            [configApiRef, getMockConfig()],
+            [opslevelApiRef, mockOpsLevelConfig],
+          ]}
+        >
+          <Campaigns serviceId={serviceId} />
+        </TestApiProvider>,
+      ),
+    );
+
+    expect(mockOpsLevelConfig.getCampaigns).toHaveBeenCalledWith(serviceId);
+
+    expect(await screen.queryByText("Campaigns")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## What changes did you make?

- Makes campaigns not show if there aren't any for the service.

## Is there a ticket that you are fixing?

Nope

## Changelog

- [x] I have added a Changie entry or given a reason why this does not need an entry in this section.

## Screenshots

*Please delete this section if it is not relevant*
![Screenshot 2024-03-15 at 5 00 33 PM](https://github.com/OpsLevel/backstage-plugin/assets/479643/c5530da9-ef97-4018-9e87-ae9450877965)

