### PR TITLE
Allows more dependabots to build up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    allow:
-      dependency-type: production
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What changes did you make?

- It is nice to have a clear list of dependabots we should hit and this allows up to 10 instead of 5 and shows all of them, not just prod ones.

## Is there a ticket that you are fixing?

[*Please link it here if so*](https://gitlab.com/jklabsinc/OpsLevel/-/issues/8629)

## Changelog

- [x] I have added a Changie entry or given a reason why this does not need an entry in this section.

No user impact